### PR TITLE
fix: correct minor typos in disk usage statistic

### DIFF
--- a/service/monitor/monitor.go
+++ b/service/monitor/monitor.go
@@ -36,12 +36,11 @@ func GetHost() *model.Host {
 	mv, _ := mem.VirtualMemory()
 	ms, _ := mem.SwapMemory()
 	u, _ := disk.Partitions(false)
-	var total uint64 = 0
+	var total uint64
 	for _, dev := range u {
 		usage, _ := disk.Usage(dev.Mountpoint)
 		total += usage.Total
 	}
-	fmt.Println(total)
 	var ip ipDotSbGeoIP
 	resp, err := http.Get("https://api-ipv4.ip.sb/geoip")
 	if err == nil {
@@ -84,7 +83,7 @@ func GetState(delay int64) *model.HostState {
 	}
 	// Disk
 	u, _ := disk.Partitions(false)
-	var used uint64 = 0
+	var used uint64
 	for _, dev := range u {
 		usage, _ := disk.Usage(dev.Mountpoint)
 		used += usage.Used


### PR DESCRIPTION
当机器中存在多个挂载点时，原先的代码只会统计`/`挂载点的使用情况。
如图所示：
![image](https://user-images.githubusercontent.com/43109504/109381331-c4068300-7914-11eb-8709-a01626ca9ab2.png)
![image](https://user-images.githubusercontent.com/43109504/109381344-dda7ca80-7914-11eb-9995-5f83949f2ed6.png)

此PR修复了这一问题。
