### PR TITLE
加强了中国大陆安装时候的稳定性和安装速度

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,12 @@ curl -L https://raw.githubusercontent.com/naiba/nezha/master/script/install.sh -
 ./nezha.sh
 ```
 
-<details>
-    <summary>国内镜像加速：（有缓存，版本更新不及时，能不用尽量不用，非作者维护）</summary>
+国内镜像加速：
 
 ```shell
-curl -L https://raw.sevencdn.com/naiba/nezha/master/script/install.sh -o nezha.sh && chmod +x nezha.sh
+curl -L https://cdn.jsdelivr.net/gh/naiba/nezha@master/script/install.sh -o nezha.sh && chmod +x nezha.sh
 CN=true ./nezha.sh
 ```
-
-</details>
 
 _\* 使用 WatchTower 可以自动更新面板，Windows 终端可以使用 nssm 配置自启动（见尾部教程）_
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -43,8 +43,6 @@ pre_check() {
     fi
 
     ## China_IP
-
-    IP_JSON=
     if [[ $(curl -m 10 -s https://api.ip.sb/geoip | grep 'China') != "" ]]; then
         echo "根据ip.sb提供的信息，当前IP可能在中国"
         while true

--- a/script/install.sh
+++ b/script/install.sh
@@ -45,25 +45,22 @@ pre_check() {
     ## China_IP
     if [[ $(curl -m 10 -s https://api.ip.sb/geoip | grep 'China') != "" ]]; then
         echo "根据ip.sb提供的信息，当前IP可能在中国"
-        while true
-        do
-            read -r -p "是否选用中国镜像完成安装? [Y/n] " input
-            case $input in
-                [yY][eE][sS]|[yY])
-                    echo "使用中国镜像"
-                    CN=true
-                    ;;
+        read -r -p "是否选用中国镜像完成安装? [Y/n] " input
+        case $input in
+            [yY][eE][sS]|[yY])
+                echo "使用中国镜像"
+                CN=true
+                ;;
 
-                [nN][oO]|[nN])
-                    echo "不使用中国镜像"      	
-                    ;;
-
-                *)
-                    echo "错误输入..."
-                    ;;
-            esac
-        done
-
+            [nN][oO]|[nN])
+                echo "不使用中国镜像"  	
+                ;;
+            *)
+                echo "使用中国镜像"
+                CN=true
+                ;;
+        esac
+    fi
     
     if [[ -z "${CN}" ]]; then
         GITHUB_RAW_URL="raw.githubusercontent.com/naiba/nezha/master"
@@ -74,7 +71,7 @@ pre_check() {
         GITHUB_RAW_URL="cdn.jsdelivr.net/gh/naiba/nezha@master"
         GITHUB_URL="dn-dao-github-mirror.daocloud.io"
         Get_Docker_URL="get.daocloud.io/docker"
-        Get_Docker_Argu=" --mirror Aliyun"
+        Get_Docker_Argu=" -s docker --mirror Aliyun"
         echo "写入/etc/hosts 52.68.132.128 ghcr.io"
         echo "52.68.132.128 ghcr.io" >> /etc/hosts
     fi

--- a/script/install.sh
+++ b/script/install.sh
@@ -66,7 +66,7 @@ pre_check() {
         GITHUB_RAW_URL="raw.githubusercontent.com/naiba/nezha/master"
         GITHUB_URL="github.com"
         Get_Docker_URL="get.docker.com"
-        Get_Docker_Argu =""
+        Get_Docker_Argu=" "
     else
         GITHUB_RAW_URL="cdn.jsdelivr.net/gh/naiba/nezha@master"
         GITHUB_URL="dn-dao-github-mirror.daocloud.io"


### PR DESCRIPTION
* 加强了中国大陆安装时候的稳定性和安装速度
* 将raw.sevencdn.com替换为cdn.jsdelivr.net
* 由于FastGit不支持对Release中非源码的加速下载，更换为DaoCloud提供的镜像
* 将中国大陆的Docker安装脚本更换为DaoCloud提供的镜像安装脚本，同时指定阿里源为Docker源(对Centos无效)
* 增加了对中国大陆安装IP的判断
* 修改了README中对镜像安装脚本的介绍