### PR TITLE
Actions推送到阿里云上海仓库 && 安装脚本修改

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -18,12 +18,20 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Log into registry
-        run: echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+        run:
+          echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+          echo "${{ secrets.ALI_PAT }}" | docker login registry.cn-shanghai.aliyuncs.com -u ${{ secrets.ALI_USER }} --password-stdin
 
-      - name: Build and push dasbboard image
+      - name: Build dasbboard image
         run: |
           go env
           go test -v ./... 
-          IMAGE_NAME=$(echo "ghcr.io/${{ github.repository_owner }}/nezha-dashboard" | tr '[:upper:]' '[:lower:]')
-          docker build -t $IMAGE_NAME -f Dockerfile .
-          docker push $IMAGE_NAME
+          docker build -t nezha-dasbboard -f Dockerfile .
+      - name: Push dasbboard image
+        run: |
+          GHRC_IMAGE_NAME=$(echo "ghcr.io/${{ github.repository_owner }}/nezha-dashboard" | tr '[:upper:]' '[:lower:]')
+          ALI_IMAGE_NAME=$(echo "registry.cn-shanghai.aliyuncs.com/${{ github.repository_owner }}/nezha-dashboard" | tr '[:upper:]' '[:lower:]')
+          docker tag nezha-dasbboard $GHRC_IMAGE_NAME
+          docker tag nezha-dasbboard $ALI_IMAGE_NAME
+          docker push $GHRC_IMAGE_NAME
+          docker push $ALI_IMAGE_NAME

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -37,7 +37,12 @@ jobs:
           docker push $ALI_IMAGE_NAME
       - name: Purge jsdelivr cache
         run: |
-          curl https://purge.jsdelivr.net/gh/${{ github.repository_owner }}/nezha@master/script/install.sh
-          curl https://purge.jsdelivr.net/gh/${{ github.repository_owner }}/nezha@master/script/nezha-agent.service
-          curl https://purge.jsdelivr.net/gh/${{ github.repository_owner }}/nezha@master/script/docker-compose.yaml
-          curl https://purge.jsdelivr.net/gh/${{ github.repository_owner }}/nezha@master/script/config.yaml
+          curl -s https://purge.jsdelivr.net/gh/${{ github.repository_owner }}/nezha@master/script/install.sh
+          curl -s https://purge.jsdelivr.net/gh/${{ github.repository_owner }}/nezha@master/script/nezha-agent.service
+          curl -s https://purge.jsdelivr.net/gh/${{ github.repository_owner }}/nezha@master/script/docker-compose.yaml
+          curl -s https://purge.jsdelivr.net/gh/${{ github.repository_owner }}/nezha@master/script/config.yaml
+          LOWER_USERNAME=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          curl -s https://purge.jsdelivr.net/gh/$LOWER_USERNAME/nezha@master/script/install.sh
+          curl -s https://purge.jsdelivr.net/gh/$LOWER_USERNAME/nezha@master/script/nezha-agent.service
+          curl -s https://purge.jsdelivr.net/gh/$LOWER_USERNAME/nezha@master/script/docker-compose.yaml
+          curl -s https://purge.jsdelivr.net/gh/$LOWER_USERNAME/nezha@master/script/config.yaml

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Log into registry
-        run:
+        run: |
           echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
           echo "${{ secrets.ALI_PAT }}" | docker login registry.cn-shanghai.aliyuncs.com -u ${{ secrets.ALI_USER }} --password-stdin
 

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -35,3 +35,9 @@ jobs:
           docker tag nezha-dasbboard $ALI_IMAGE_NAME
           docker push $GHRC_IMAGE_NAME
           docker push $ALI_IMAGE_NAME
+      - name: Purge jsdelivr cache
+        run: |
+          curl https://purge.jsdelivr.net/gh/${{ github.repository_owner }}/nezha@master/script/install.sh
+          curl https://purge.jsdelivr.net/gh/${{ github.repository_owner }}/nezha@master/script/nezha-agent.service
+          curl https://purge.jsdelivr.net/gh/${{ github.repository_owner }}/nezha@master/script/docker-compose.yaml
+          curl https://purge.jsdelivr.net/gh/${{ github.repository_owner }}/nezha@master/script/config.yaml

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -30,7 +30,10 @@ jobs:
       - name: Push dasbboard image
         run: |
           GHRC_IMAGE_NAME=$(echo "ghcr.io/${{ github.repository_owner }}/nezha-dashboard" | tr '[:upper:]' '[:lower:]')
-          ALI_IMAGE_NAME=$(echo "registry.cn-shanghai.aliyuncs.com/${{ github.repository_owner }}/nezha-dashboard" | tr '[:upper:]' '[:lower:]')
+          if [ ${{ github.repository_owner }} = "naiba" ]
+          then ALI_IMAGE_NAME=$(echo "registry.cn-shanghai.aliyuncs.com/naibahq/nezha-dashboard")
+          else ALI_IMAGE_NAME=$(echo "registry.cn-shanghai.aliyuncs.com/${{ github.repository_owner }}/nezha-dashboard" | tr '[:upper:]' '[:lower:]')
+          fi
           docker tag nezha-dasbboard $GHRC_IMAGE_NAME
           docker tag nezha-dasbboard $ALI_IMAGE_NAME
           docker push $GHRC_IMAGE_NAME

--- a/script/docker-compose.yaml
+++ b/script/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   dashboard:
-    image: ghcr.io/naiba/nezha-dashboard
+    image: image_url
     restart: always
     volumes:
       - ./data:/dashboard/data

--- a/script/install.sh
+++ b/script/install.sh
@@ -73,7 +73,7 @@ pre_check() {
         GITHUB_URL="dn-dao-github-mirror.daocloud.io"
         Get_Docker_URL="get.daocloud.io/docker"
         Get_Docker_Argu=" -s docker --mirror Aliyun"
-        Docker_IMG="registry.cn-shanghai.aliyuncs.com/erope/nezha-dashboard"
+        Docker_IMG="registry.cn-shanghai.aliyuncs.com/naiba/nezha-dashboard"
     fi
 }
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -67,11 +67,13 @@ pre_check() {
         GITHUB_URL="github.com"
         Get_Docker_URL="get.docker.com"
         Get_Docker_Argu=" "
+        Docker_IMG="ghcr.io/naiba/nezha-dashboard"
     else
         GITHUB_RAW_URL="cdn.jsdelivr.net/gh/naiba/nezha@master"
         GITHUB_URL="dn-dao-github-mirror.daocloud.io"
         Get_Docker_URL="get.daocloud.io/docker"
         Get_Docker_Argu=" -s docker --mirror Aliyun"
+        Docker_IMG="registry.cn-shanghai.aliyuncs.com/erope/nezha-dashboard"
     fi
 }
 
@@ -264,6 +266,7 @@ modify_dashboard_config() {
     sed -i "s/nz_site_title/${nz_site_title}/" ${NZ_DASHBOARD_PATH}/data/config.yaml
     sed -i "s/nz_site_port/${nz_site_port}/" ${NZ_DASHBOARD_PATH}/docker-compose.yaml
     sed -i "s/nz_grpc_port/${nz_grpc_port}/" ${NZ_DASHBOARD_PATH}/docker-compose.yaml
+    sed -i "s/image_url/${Docker_IMG}/" ${NZ_DASHBOARD_PATH}/docker-compose.yaml
 
     echo -e "面板配置 ${green}修改成功，请稍等重启生效${plain}"
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -67,13 +67,13 @@ pre_check() {
         GITHUB_URL="github.com"
         Get_Docker_URL="get.docker.com"
         Get_Docker_Argu=" "
-        Docker_IMG="ghcr.io/naiba/nezha-dashboard"
+        Docker_IMG="ghcr.io\/naiba\/nezha-dashboard"
     else
         GITHUB_RAW_URL="cdn.jsdelivr.net/gh/naiba/nezha@master"
         GITHUB_URL="dn-dao-github-mirror.daocloud.io"
         Get_Docker_URL="get.daocloud.io/docker"
         Get_Docker_Argu=" -s docker --mirror Aliyun"
-        Docker_IMG="registry.cn-shanghai.aliyuncs.com/naiba/nezha-dashboard"
+        Docker_IMG="registry.cn-shanghai.aliyuncs.com\/naiba\/nezha-dashboard"
     fi
 }
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -73,7 +73,7 @@ pre_check() {
         GITHUB_URL="dn-dao-github-mirror.daocloud.io"
         Get_Docker_URL="get.daocloud.io/docker"
         Get_Docker_Argu=" -s docker --mirror Aliyun"
-        Docker_IMG="registry.cn-shanghai.aliyuncs.com\/naiba\/nezha-dashboard"
+        Docker_IMG="registry.cn-shanghai.aliyuncs.com\/naibahq\/nezha-dashboard"
     fi
 }
 


### PR DESCRIPTION
Actions推送到阿里云上海仓库 && 安装脚本修改
注意:
* 最好是阿里云上海，Github的Action运行环境是美国Azure，走上海联通去阿里云上海推送很快，换区域需要修改，push上去大概10M
* 命名空间和名称均已经写死
* secrets.ALI_PAT和secrets.ALI_USER需要自行设置
* jsdelivr的缓存刷新提交后大概需要15分钟才会在网宿的边缘节点生效
* 缓存刷新那边处理了小写是因为我用户名是大写的 方便测试干脆一起处理下小写
* 国内安装源会从阿里云上海拉取镜像