### PR TITLE
解决排除网卡不生效的bug

### DIFF
--- a/cmd/agent/monitor/monitor.go
+++ b/cmd/agent/monitor/monitor.go
@@ -139,7 +139,7 @@ func getDiskTotalAndUsed() (total uint64, used uint64) {
 
 func isListContainsStr(list []string, str string) bool {
 	for i := 0; i < len(list); i++ {
-		if strings.Contains(list[i], str) {
+		if strings.Contains(str, list[i]) {
 			return true
 		}
 	}


### PR DESCRIPTION
流量统计排除了内网，docker等并没有生效，看了下是包含的顺序不对