### PR TITLE
:sparkles: 反向代理 gRPC 端口（支持 Cloudflare CDN）

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,10 +322,10 @@ restart() {
 </details>
 
 <details>
-    <summary>Agent 连接 Dashboard 域名开启 Cloudflare CDN</summary>
-根据 Cloudflare gRPC 的要求：gRPC 服务必须侦听 443 端口 且必须支持 TLS 和 HTTP/2。我们可以使用 nginx 反向代理 gRPC 并配置 SSL/TLS 证书。
+    <summary>反向代理 gRPC 端口（支持 Cloudflare CDN）</summary>
+使用 Nginx 或者 Caddy 反向代理 gRPC
 
-- nginx 配置，比如 Agent 连接 Dashboard 的域名为 ip-to-dashboard.nai.ba，为 nginx 添加如下配置，然后重新启动 nginx 或者重新加载配置文件。
+- Nginx 配置
 
 ```nginx
 server {
@@ -339,18 +339,44 @@ server {
     underscores_in_headers on;
 
     location / {
+        grpc_read_timeout 300s;
+        grpc_send_timeout 300s;
         grpc_pass grpc://localhost:5555;
     }
 }
 ```
 
-- Agent 端配置，编辑 `/etc/systemd/system/nezha-agent.service`，在 `ExecStart=` 这一行的末尾加上 `--tls`，然后重启 nezha-agent.service。例如：
+- Caddy 配置
 
-```bash
-ExecStart=/opt/nezha/agent/nezha-agent -s ip-to-dashboard.nai.ba:443 -p xxxxxx --tls
+```Caddyfile
+ip-to-dashboard.nai.ba:443 { 
+    reverse_proxy {
+        to localhost:5555
+        transport http {
+            versions h2c 2
+        }
+    }
+}
 ```
 
-- 在 Cloudflare 中将对应的域名解析设置橙色云开启CDN，并在网络选项中启用gRPC。
+
+Dashboard 面板端配置
+
+- 首先登录面板进入管理后台 打开设置页面，在 `未接入CDN的面板服务器域名/IP` 中填入上一步在 Nginx 或 Caddy 中配置的域名 比如 `ip-to-dashboard.nai.ba` ，并保存。
+- 然后在面板服务器中，打开 /opt/nezha/dashboard/data/config.yaml 文件，将 `proxygrpcport` 修改为 Nginx 或 Caddy 监听的端口，比如上一步设置的 `443` ；因为我们在 Nginx 或 Caddy 中开启了 SSL/TLS，所以需要将 `tls` 设置为 `true` ；修改完成后重启面板。
+
+
+Agent 端配置
+
+- 登录面板管理后台，复制一键安装命令，在对应的服务器上面执行一键安装命令重新安装 agent 端即可。
+
+
+开启 Cloudflare CDN（可选）
+
+根据 Cloudflare gRPC 的要求：gRPC 服务必须侦听 443 端口 且必须支持 TLS 和 HTTP/2。
+所以如果需要开启CDN，必须在配置 Nginx 或者 Caddy 反向代理 gRPC 时使用 443 端口，并配置证书（Caddy 会自动申请并配置证书）。
+
+- 登录 Cloudflare，选择使用的域名。打开 `网络` 选项将 `gRPC` 开关打开，打开 `DNS` 选项，找到 Nginx 或 Caddy 反代 gRPC 配置的域名的解析记录，打开橙色云启用CDN。
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ server {
 - Caddy 配置
 
 ```Caddyfile
-ip-to-dashboard.nai.ba:443 { 
+ip-to-dashboard.nai.ba:443 { # 你的 Agent 连接 Dashboard 的域名
     reverse_proxy {
         to localhost:5555
         transport http {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -218,6 +218,8 @@ func doTask(task *pb.Task) {
 		handleCommandTask(task, &result)
 	case model.TaskTypeUpgrade:
 		handleUpgradeTask(task, &result)
+	case model.TaskTypeKeepalive:
+		return
 	default:
 		println("不支持的任务：", task)
 	}

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -193,6 +193,7 @@ func main() {
 	go rpc.ServeRPC(dao.Conf.GRPCPort)
 	serviceSentinelDispatchBus := make(chan model.Monitor)
 	go rpc.DispatchTask(serviceSentinelDispatchBus)
+	go rpc.DispatchKeepalive()
 	go dao.AlertSentinelStart()
 	dao.NewServiceSentinel(serviceSentinelDispatchBus)
 	srv := controller.ServeWeb(dao.Conf.HTTPPort)

--- a/cmd/dashboard/rpc/rpc.go
+++ b/cmd/dashboard/rpc/rpc.go
@@ -63,7 +63,7 @@ func DispatchKeepalive() {
 		dao.SortedServerLock.RLock()
 		defer dao.SortedServerLock.RUnlock()
 		for i := 0; i < len(dao.SortedServerList); i++ {
-			if dao.SortedServerList[i] == nil || dao.SortedServerList[i].TaskStream == nil || dao.SortedServerList[i].TaskStream.Context().Err() != nil {
+			if dao.SortedServerList[i] == nil || dao.SortedServerList[i].TaskStream == nil {
 				continue
 			}
 

--- a/cmd/dashboard/rpc/rpc.go
+++ b/cmd/dashboard/rpc/rpc.go
@@ -57,3 +57,17 @@ func DispatchTask(serviceSentinelDispatchBus <-chan model.Monitor) {
 		dao.SortedServerLock.RUnlock()
 	}
 }
+
+func DispatchKeepalive() {
+	dao.Cron.AddFunc("@every 60s", func() {
+		dao.SortedServerLock.RLock()
+		defer dao.SortedServerLock.RUnlock()
+		for i := 0; i < len(dao.SortedServerList); i++ {
+			if dao.SortedServerList[i] == nil || dao.SortedServerList[i].TaskStream == nil || dao.SortedServerList[i].TaskStream.Context().Err() != nil {
+				continue
+			}
+
+			dao.SortedServerList[i].TaskStream.Send(&pb.Task{Type: model.TaskTypeKeepalive})
+		}
+	})
+}

--- a/model/config.go
+++ b/model/config.go
@@ -39,6 +39,8 @@ type Config struct {
 	GRPCPort                   uint
 	GRPCHost                   string
 	EnableIPChangeNotification bool
+	ProxyGRPCPort              uint
+	TLS                        bool
 
 	// IP变更提醒
 	Cover                 uint8  // 覆盖范围

--- a/model/monitor.go
+++ b/model/monitor.go
@@ -17,6 +17,7 @@ const (
 	TaskTypeCommand
 	TaskTypeTerminal
 	TaskTypeUpgrade
+	TaskTypeKeepalive
 )
 
 type TerminalTask struct {

--- a/resource/template/component/server.html
+++ b/resource/template/component/server.html
@@ -31,7 +31,8 @@
                     {{if .Conf.GRPCHost}}
                     curl -L https://raw.githubusercontent.com/naiba/nezha/master/script/install.sh -o nezha.sh && chmod
                     +x nezha.sh && sudo ./nezha.sh install_agent <code class="command">{{.Conf.GRPCHost}}</code> <code
-                        class="command">{{.Conf.GRPCPort}}</code> <code class="command hostSecret"></code>
+                        class="command">{{if .Conf.ProxyGRPCPort}}{{.Conf.ProxyGRPCPort}}{{else}}{{.Conf.GRPCPort}}{{end}}</code> <code
+                        class="command hostSecret"></code> <code class="command">{{if .Conf.TLS}}--tls{{end}}</code>
                     {{else}}
                     请先在设置页面配置 未接入CDN的面板服务器域名/IP
                     {{end}}

--- a/resource/template/dashboard/server.html
+++ b/resource/template/dashboard/server.html
@@ -40,7 +40,7 @@
                     <td>{{$server.Secret}}</td>
                     <td>
                         <button class="ui icon green mini button"
-                            data-clipboard-text="{{if $.Conf.GRPCHost}}curl -L https://raw.githubusercontent.com/naiba/nezha/master/script/install.sh -o nezha.sh && chmod +x nezha.sh && sudo ./nezha.sh install_agent {{$.Conf.GRPCHost}} {{$.Conf.GRPCPort}} {{$server.Secret}}{{else}}请先在设置页面配置 未接入CDN的面板服务器域名/IP{{end}}"
+                            data-clipboard-text="{{if $.Conf.GRPCHost}}curl -L https://raw.githubusercontent.com/naiba/nezha/master/script/install.sh -o nezha.sh && chmod +x nezha.sh && sudo ./nezha.sh install_agent {{$.Conf.GRPCHost}} {{if $.Conf.ProxyGRPCPort}}{{$.Conf.ProxyGRPCPort}}{{else}}{{$.Conf.GRPCPort}}{{end}} {{$server.Secret}}{{if $.Conf.TLS}} --tls{{end}}{{else}}请先在设置页面配置 未接入CDN的面板服务器域名/IP{{end}}"
                             data-tooltip="点击复制安装命令">
                             <i class="linux icon"></i>
                         </button>

--- a/script/install.sh
+++ b/script/install.sh
@@ -203,8 +203,8 @@ install_agent() {
         mv nezha-agent $NZ_AGENT_PATH &&
         rm -rf nezha-agent_linux_${os_arch}.tar.gz README.md
 
-    if [[ $# == 3 ]]; then
-        modify_agent_config $1 $2 $3
+    if [ $# -ge 3 ]; then
+        modify_agent_config "$@"
     else
         modify_agent_config 0
     fi
@@ -223,7 +223,7 @@ modify_agent_config() {
         return 0
     fi
 
-    if [[ $# != 3 ]]; then
+    if [ $# -lt 3 ]; then
         echo "请先在管理面板上添加Agent，记录下密钥" &&
             read -ep "请输入一个解析到面板所在IP的域名（不可套CDN）: " nz_grpc_host &&
             read -ep "请输入面板RPC端口: (5555)" nz_grpc_port &&
@@ -242,11 +242,15 @@ modify_agent_config() {
         nz_client_secret=$3
     fi
 
-
-
     sed -i "s/nz_grpc_host/${nz_grpc_host}/" ${NZ_AGENT_SERVICE}
     sed -i "s/nz_grpc_port/${nz_grpc_port}/" ${NZ_AGENT_SERVICE}
     sed -i "s/nz_client_secret/${nz_client_secret}/" ${NZ_AGENT_SERVICE}
+
+    shift 3
+    if [ $# -gt 0 ]; then
+        args=" $*"
+        sed -i "/ExecStart/ s/$/${args}/" ${NZ_AGENT_SERVICE}
+    fi
 
     echo -e "Agent配置 ${green}修改成功，请稍等重启生效${plain}"
 
@@ -558,8 +562,9 @@ if [[ $# > 0 ]]; then
         uninstall_dashboard 0
         ;;
     "install_agent")
-        if [[ $# == 4 ]]; then
-            install_agent $2 $3 $4
+        shift
+        if [ $# -ge 3 ]; then
+            install_agent "$@"
         else
             install_agent 0
         fi


### PR DESCRIPTION
您好，前些天我提供了反代 gRPC 的方法。但是后来发现因为 Nginx 或者 Cloudflare 的一些限制。如果面板和服务器的 ServerStream 连接长时间没有数据传输，Nginx 或者 Cloudflare 会断开连接，从而导致 Agent 监控端与面板服务器的 gRPC 连接频繁断开重连，导致面板内存占用一直增高。我做了一些修改，面板每隔一段时间（目前设置的60秒）会向所有服务器发送一次数据来保持连接不被断开，经过测试目前没有出现 Nginx 或者 Cloudflare 超时时间限制导致的重连问题了。我也对前端和脚本做了一些修改，以方便使用反代 gRPC 时生成一键安装命令安装 Agent 监控端。