### PR TITLE
Agent支持IBM-S390X和RISCV64架构

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,8 @@ builds:
       - amd64
       - mips
       - mipsle
+      - s390x
+      - riscv64
     gomips:
       - softfloat
     ignore:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <br>
   <small><i>LOGO designed by <a href="https://xio.ng" target="_blank">熊大</a> .</i></small>
   <br><br>
-<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Dashboard%20image?label=Dash%20v0.12.1&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/github/v/release/naiba/nezha?color=brightgreen&label=Agent&style=for-the-badge&logo=github">&nbsp;<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Agent%20release?label=Agent%20CI&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/badge/Installer-v0.8.0-brightgreen?style=for-the-badge&logo=linux">
+<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Dashboard%20image?label=Dash%20v0.12.1&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/github/v/release/naiba/nezha?color=brightgreen&label=Agent&style=for-the-badge&logo=github">&nbsp;<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Agent%20release?label=Agent%20CI&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/badge/Installer-v0.8.1-brightgreen?style=for-the-badge&logo=linux">
   <br>
   <br>
   <p>:trollface: <b>哪吒监控</b> 一站式轻监控轻运维系统。支持系统状态、HTTP(SSL 证书变更、即将到期、到期)、TCP、Ping 监控报警，计划任务和在线终端。</p>

--- a/script/install.sh
+++ b/script/install.sh
@@ -11,7 +11,7 @@ NZ_BASE_PATH="/opt/nezha"
 NZ_DASHBOARD_PATH="${NZ_BASE_PATH}/dashboard"
 NZ_AGENT_PATH="${NZ_BASE_PATH}/agent"
 NZ_AGENT_SERVICE="/etc/systemd/system/nezha-agent.service"
-NZ_VERSION="v0.8.0"
+NZ_VERSION="v0.8.1"
 
 red='\033[0;31m'
 green='\033[0;32m'
@@ -40,6 +40,10 @@ pre_check() {
         os_arch="arm64"
     elif [[ $(uname -m | grep 'arm') != "" ]]; then
         os_arch="arm"
+    elif [[ $(uname -m | grep 's390x') != "" ]]; then
+        os_arch="s390x"
+    elif [[ $(uname -m | grep 'riscv64') != "" ]]; then
+        os_arch="riscv64"
     fi
 
     ## China_IP


### PR DESCRIPTION
为Agent添加更多架构支持
S390X已测试(IBM LinuxONE) 除CPU名称无法获取外均正常
RISCV64未测试