### PR TITLE
添加统计周期单位cycle_unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ URL 里面也可放置占位符，请求时会进行简单的字符串替换。
   - transfer_in_cycle 周期内的入站流量
   - transfer_out_cycle 周期内的出站流量
   - transfer_all_cycle 周期内双向流量和
-- cycle_start 周期开始日期（可以是你机器计费周期的开始日期）
+- cycle_start 周期开始日期（可以是你机器计费周期的开始日期），RFC3339时间格式，例如北京时间为`2022-01-11T08:00:00.00+08:00`
 - cycle_interval 小时（可以设为 1 月，30\*24）
 - min/max、cover、ignore 参考基本规则配置
 - 示例: ID 为 3 的机器（ignore 里面定义）的每月 15 号计费的出站月流量 1T 报警 `[{"type":"transfer_out_cycle","max":1000000000000,"cycle_start":"2021-07-15T08:00:00Z","cycle_interval":730,"cover":1,"ignore":{"3":true}}]`

--- a/README.md
+++ b/README.md
@@ -140,10 +140,12 @@ URL 里面也可放置占位符，请求时会进行简单的字符串替换。
   - transfer_in_cycle 周期内的入站流量
   - transfer_out_cycle 周期内的出站流量
   - transfer_all_cycle 周期内双向流量和
-- cycle_start 周期开始日期（可以是你机器计费周期的开始日期），RFC3339时间格式，例如北京时间为`2022-01-11T08:00:00.00+08:00`
-- cycle_interval 小时（可以设为 1 月，30\*24）
+- cycle_start 统计周期开始日期（可以是你机器计费周期的开始日期），RFC3339时间格式，例如北京时间为`2022-01-11T08:00:00.00+08:00`
+- cycle_interval 每隔多少个周期单位（例如，周期单位为天，该值为7，则代表每隔7天统计一次）
+- cycle_unit 统计周期单位，默认`hour`,可选(`hour`, `day`, `week`, `month`, `year`)
 - min/max、cover、ignore 参考基本规则配置
-- 示例: ID 为 3 的机器（ignore 里面定义）的每月 15 号计费的出站月流量 1T 报警 `[{"type":"transfer_out_cycle","max":1000000000000,"cycle_start":"2021-07-15T08:00:00Z","cycle_interval":730,"cover":1,"ignore":{"3":true}}]`
+- 示例: ID 为 3 的机器（ignore 里面定义）的每月 15 号计费的出站月流量 1T 报警 `[{"type":"transfer_out_cycle","max":1000000000000,"cycle_start":"2021-07-15T08:00:00Z","cycle_interval":1,"cycle_unit":"month","cover":1,"ignore":{"3":true}}]`
+- [![7QKaUx.md.png](https://s4.ax1x.com/2022/01/13/7QKaUx.md.png)](https://imgtu.com/i/7QKaUx)
 
 </details>
 

--- a/model/rule.go
+++ b/model/rule.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"gorm.io/gorm"
-	"github.com/gorhill/cronexpr"
 )
 
 const (
@@ -25,7 +24,8 @@ type Rule struct {
 	Min           float64         `json:"min,omitempty"`            // 最小阈值 (百分比、字节 kb ÷ 1024)
 	Max           float64         `json:"max,omitempty"`            // 最大阈值 (百分比、字节 kb ÷ 1024)
 	CycleStart    time.Time       `json:"cycle_start,omitempty"`    // 流量统计的开始时间
-	CycleInterval string          `json:"cycle_interval,omitempty"` // crontab 表达式
+	CycleInterval uint64          `json:"cycle_interval,omitempty"` // 流量统计周期
+	CycleUnit			string					`json:"cycle_unit,omitempty"` 		// 流量统计周期单位，默认hour,可选(hour, day, week, month, year)
 	Duration      uint64          `json:"duration,omitempty"`       // 持续时间 (秒)
 	Cover         uint64          `json:"cover,omitempty"`          // 覆盖范围 RuleCoverAll/IgnoreAll
 	Ignore        map[uint64]bool `json:"ignore,omitempty"`         // 覆盖范围的排除
@@ -89,21 +89,21 @@ func (u *Rule) Snapshot(cycleTransferStats *CycleTransferStats, server *Server, 
 		}
 	case "transfer_in_cycle":
 		src = float64(server.State.NetInTransfer - uint64(server.PrevHourlyTransferIn))
-		if u.CycleInterval != nil {
+		if u.CycleInterval != 0 {
 			var res NResult
 			db.Model(&Transfer{}).Select("SUM(`in`) AS n").Where("created_at > ? AND server_id = ?", u.GetTransferDurationStart(), server.ID).Scan(&res)
 			src += float64(res.N)
 		}
 	case "transfer_out_cycle":
 		src = float64(server.State.NetOutTransfer - uint64(server.PrevHourlyTransferOut))
-		if u.CycleInterval != nil {
+		if u.CycleInterval != 0 {
 			var res NResult
 			db.Model(&Transfer{}).Select("SUM(`out`) AS n").Where("created_at > ? AND server_id = ?", u.GetTransferDurationStart(), server.ID).Scan(&res)
 			src += float64(res.N)
 		}
 	case "transfer_all_cycle":
 		src = float64(server.State.NetOutTransfer - uint64(server.PrevHourlyTransferOut) + server.State.NetInTransfer - uint64(server.PrevHourlyTransferIn))
-		if u.CycleInterval != nil {
+		if u.CycleInterval != 0 {
 			var res NResult
 			db.Model(&Transfer{}).Select("SUM(`in`+`out`) AS n").Where("created_at > ?  AND server_id = ?", u.GetTransferDurationStart(), server.ID).Scan(&res)
 			src += float64(res.N)
@@ -164,25 +164,80 @@ func (rule Rule) IsTransferDurationRule() bool {
 }
 
 func (rule Rule) GetTransferDurationStart() time.Time {
-	expr := cronexpr.MustParse(rule.CycleInterval)
-	durationStart := rule.CycleInterval
-	nextTime := expr.Next(rule.CycleStart)
-	for nextTime.Before(time.Now()) {
-		durationStart = nextTime
-		nextTime = expr.Next(rule.CycleStart)
+	// Accept uppercase and lowercase
+	unit := strings.ToLower(rule.CycleUnit)
+	startTime := rule.CycleStart
+	var nextTime time.Time
+	switch unit {
+	case "year":
+		nextTime = startTime.AddDate(int(rule.CycleInterval), 0, 0)
+		for time.Now().After(nextTime) {
+			startTime = nextTime
+			nextTime = nextTime.AddDate(int(rule.CycleInterval), 0, 0)
+		}
+	case "month":
+		nextTime = startTime.AddDate(0, int(rule.CycleInterval), 0)
+		for time.Now().After(nextTime) {
+			startTime = nextTime
+			nextTime = nextTime.AddDate(0, int(rule.CycleInterval), 0)
+		}
+	case "week":
+		nextTime = startTime.AddDate(0, 0, 7 * int(rule.CycleInterval))
+		for time.Now().After(nextTime) {
+			startTime = nextTime
+			nextTime = nextTime.AddDate(0, 0, 7 * int(rule.CycleInterval))
+		}
+	case "day":
+		nextTime = startTime.AddDate(0, 0, int(rule.CycleInterval))
+		for time.Now().After(nextTime) {
+			startTime = nextTime
+			nextTime = nextTime.AddDate(0, 0, int(rule.CycleInterval))
+		}
+	default:
+		// For hour unit or not set.
+		interval := 3600 * int64(rule.CycleInterval)
+		startTime = time.Unix(rule.CycleStart.Unix()+(time.Now().Unix()-rule.CycleStart.Unix())/interval*interval, 0)
 	}
-	// TODO: catch the err from parse String and Next function.
-	return time.Unix(durationStart.Unix, 0)
+
+	return startTime
 }
 
 func (rule Rule) GetTransferDurationEnd() time.Time {
-	expr := cronexpr.MustParse(rule.CycleInterval)
-	durationStart := rule.CycleInterval
-	nextTime := expr.Next(rule.CycleStart)
-	for nextTime.Before(time.Now()) {
-		durationStart = nextTime
-		nextTime = expr.Next(rule.CycleStart)
+	// Accept uppercase and lowercase
+	unit := strings.ToLower(rule.CycleUnit)
+	startTime := rule.CycleStart
+	var nextTime time.Time
+	switch unit {
+	case "year":
+		nextTime = startTime.AddDate(int(rule.CycleInterval), 0, 0)
+		for time.Now().After(nextTime) {
+			startTime = nextTime
+			nextTime = nextTime.AddDate(int(rule.CycleInterval), 0, 0)
+		}
+	case "month":
+		nextTime = startTime.AddDate(0, int(rule.CycleInterval), 0)
+		for time.Now().After(nextTime) {
+			startTime = nextTime
+			nextTime = nextTime.AddDate(0, int(rule.CycleInterval), 0)
+		}
+	case "week":
+		nextTime = startTime.AddDate(0, 0, 7 * int(rule.CycleInterval))
+		for time.Now().After(nextTime) {
+			startTime = nextTime
+			nextTime = nextTime.AddDate(0, 0, 7 * int(rule.CycleInterval))
+		}
+	case "day":
+		nextTime = startTime.AddDate(0, 0, int(rule.CycleInterval))
+		for time.Now().After(nextTime) {
+			startTime = nextTime
+			nextTime = nextTime.AddDate(0, 0, int(rule.CycleInterval))
+		}
+	default:
+		// For hour unit or not set.
+		interval := 3600 * int64(rule.CycleInterval)
+		startTime = time.Unix(rule.CycleStart.Unix()+(time.Now().Unix()-rule.CycleStart.Unix())/interval*interval, 0)
+		nextTime = time.Unix(startTime.Unix() + interval, 0)
 	}
-	// TODO: catch the err from parse String and Next function.
-	return time.Unix(nextTime.Unix, 0)
+
+	return nextTime
 }

--- a/resource/template/theme-mdui/viewpassword.html
+++ b/resource/template/theme-mdui/viewpassword.html
@@ -17,18 +17,30 @@
 
 <body>
   <div class="mdui-container" id="container">
+    <div class="mdui-dialog mdui-dialog-prompt mdui-dialog-open">
+      <div class="mdui-dialog-title">验证查看密码</div>
+
+      <div class="mdui-dialog-content">
+        <div class="mdui-textfield">
+          <i class="mdui-icon material-icons">lock</i>
+          <label class="mdui-textfield-label">密码</label>
+          <input class="mdui-textfield-input" type="password" id="password">
+        </div>
+      </div>
+
+      <div class="mdui-dialog-actions">
+        <button class="mdui-btn mdui-ripple mdui-text-color-primary" id="confimBtn">验证</button>
+      </div>
+    </div>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/mdui@1.0.2/dist/js/mdui.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/jquery@3.4.1/dist/jquery.min.js"></script>
   <script>
-    var content = '<div class="mdui-textfield">' +
-      '<i class="mdui-icon material-icons">lock</i>' +
-      '<label class="mdui-textfield-label">密码</label>' +
-      '<input class="mdui-textfield-input" type="password">' +
-      '</div>';
-
-    var onConfirm = async function(pwd) {
+    var $input = mdui.$('#container').find('.mdui-textfield-input');
+    var $dialog = new mdui.Dialog(mdui.$('.mdui-dialog'));
+    var onConfirm = async function() {
+      var pwd = $input.val();
       const res = await fetch("/view-password", {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
@@ -39,49 +51,30 @@
         if (res.redirected) {
           window.location.href = res.url;
         } else {
-          window.location.reload();
           mdui.snackbar({
            message: '密码错误',
            position: 'top',
+           timeout: 2000,
          });
           mdui.mutation();
+          $input[0].focus();
         }
       }
     };
 
-    var onConfirmClick = function (dialog) {
-      var value = dialog.$element.find('.mdui-textfield-input').val();
-      onConfirm(value, dialog);
-    };
-
-    var checkPwd = mdui.dialog({
-      title: '验证查看密码',
-      content: content,
-      buttons: [
-        {
-          text: '验证',
-          bold: false,
-          onClick: onConfirmClick,
-        }
-      ],
-      cssClass: 'mdui-dialog-prompt',
-      modal: true,
-      onOpen: function (dialog) {
-        var $input = dialog.$element.find('.mdui-textfield-input');
-        mdui.updateTextFields($input);
-        $input[0].focus();
-        $input.on('keydown', function (event) {
-          if (event.keyCode === 13) {
-            var value = dialog.$element.find('.mdui-textfield-input').val();
-            onConfirm(value, dialog);
-            return false;
-          }
-          return;
-        });
-      },
+    mdui.updateTextFields($input);
+    $input.on('keydown', function (event) {
+      if (event.keyCode === 13) {
+        var value = $input.val();
+        onConfirm(value);
+        return false;
+      }
+      return;
     });
+    document.getElementById('confimBtn').addEventListener('click', onConfirm);
 
-    $('#container').add(checkPwd);
+    $dialog.open();
+    $input[0].focus();
     mdui.mutation();
   </script>
 </body>

--- a/resource/template/theme-mdui/viewpassword.html
+++ b/resource/template/theme-mdui/viewpassword.html
@@ -57,7 +57,6 @@
            timeout: 2000,
          });
           mdui.mutation();
-          $input[0].focus();
         }
       }
     };

--- a/service/dao/alertsentinel.go
+++ b/service/dao/alertsentinel.go
@@ -38,10 +38,11 @@ func addCycleTransferStatsInfo(alert *model.AlertRule) {
 		}
 		if AlertsCycleTransferStatsStore[alert.ID] == nil {
 			from := alert.Rules[j].GetTransferDurationStart()
+			to := alert.Rules[j].GetTransferDurationEnd()
 			AlertsCycleTransferStatsStore[alert.ID] = &model.CycleTransferStats{
 				Name:       alert.Name,
 				From:       from,
-				To:         from.Add(time.Hour * time.Duration(alert.Rules[j].CycleInterval)),
+				To:         to,
 				Max:        uint64(alert.Rules[j].Max),
 				Min:        uint64(alert.Rules[j].Min),
 				ServerName: make(map[uint64]string),


### PR DESCRIPTION
月流量报警

- type
  - transfer_in_cycle 周期内的入站流量
  - transfer_out_cycle 周期内的出站流量
  - transfer_all_cycle 周期内双向流量和
- cycle_start 统计周期开始日期（可以是你机器计费周期的开始日期），RFC3339时间格式，例如北京时间为`2022-01-11T08:00:00.00+08:00`
- cycle_interval 每隔多少个周期单位（例如，周期单位为天，该值为7，则代表每隔7天统计一次）
- cycle_unit 统计周期单位，默认`hour`,可选(`hour`, `day`, `week`, `month`, `year`)
- min/max、cover、ignore 参考基本规则配置
- 示例: ID 为 3 的机器（ignore 里面定义）的每月 15 号计费的出站月流量 1T 报警 `[{"type":"transfer_out_cycle","max":1000000000000,"cycle_start":"2021-07-15T08:00:00+08:00","cycle_interval":1,"cycle_unit":"month","cover":1,"ignore":{"3":true}}]`
- [![7QKaUx.md.png](https://s4.ax1x.com/2022/01/13/7QKaUx.md.png)](https://imgtu.com/i/7QKaUx)