### PR TITLE
修复管理后台页面新添加CoverIgnoreAll类型服务需要重启docker镜像的问题.

### DIFF
--- a/cmd/dashboard/controller/member_api.go
+++ b/cmd/dashboard/controller/member_api.go
@@ -235,6 +235,7 @@ func (ma *memberAPI) addOrEditMonitor(c *gin.Context) {
 		m.Cover = mf.Cover
 		m.Notify = mf.Notify == "on"
 		m.Duration = mf.Duration
+		err = m.InitSkipServers()
 	}
 	if err == nil {
 		if m.ID == 0 {

--- a/model/monitor.go
+++ b/model/monitor.go
@@ -79,3 +79,15 @@ func (m *Monitor) AfterFind(tx *gorm.DB) error {
 func IsServiceSentinelNeeded(t uint64) bool {
 	return t != TaskTypeCommand && t != TaskTypeTerminal && t != TaskTypeUpgrade
 }
+
+func (m *Monitor) InitSkipServers() error {
+	var skipServers []uint64
+	if err := json.Unmarshal([]byte(m.SkipServersRaw), &skipServers); err != nil {
+		return err
+	}
+	m.SkipServers = make(map[uint64]bool)
+	for i := 0; i < len(skipServers); i++ {
+		m.SkipServers[skipServers[i]] = true
+	}
+	return nil
+}


### PR DESCRIPTION
由于后台管理页面提交新的服务时，初始化`Monitor`没有给`SkipServers`赋值，而`Monitor`的AfterFind仅在数据库做查询动作时才更新，而该动作仅在整个程序初始化才会做查询动作，导致新增服务的`SkipSevers`一直为`nil`.
https://github.com/naiba/nezha/blob/3144620a1599fc33a9b05f94c61b5c9e329ca696/cmd/dashboard/controller/member_api.go#L225-L259


而到了执行任务时，由于`task.SkipServers`实际为`nil`，导致在MonitorCoverIgnoreAll时进入了条件语句，跳出循环，导致没有执行任务。
https://github.com/naiba/nezha/blob/3144620a1599fc33a9b05f94c61b5c9e329ca696/cmd/dashboard/rpc/rpc.go#L47-L51