### PR TITLE
feat: 通过传递客户端Cookie的方式使web终端功能兼容被Cloudflare Access保护的面板

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <br>
   <small><i>LOGO designed by <a href="https://xio.ng" target="_blank">熊大</a> .</i></small>
   <br><br>
-<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Dashboard%20image?label=Dash%20v0.12.18&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/github/v/release/naiba/nezha?color=brightgreen&label=Agent&style=for-the-badge&logo=github">&nbsp;<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Agent%20release?label=Agent%20CI&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/badge/Installer-v0.8.2-brightgreen?style=for-the-badge&logo=linux">
+<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Dashboard%20image?label=Dash%20v0.12.19&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/github/v/release/naiba/nezha?color=brightgreen&label=Agent&style=for-the-badge&logo=github">&nbsp;<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Agent%20release?label=Agent%20CI&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/badge/Installer-v0.8.2-brightgreen?style=for-the-badge&logo=linux">
   <br>
   <br>
   <p>:trollface: <b>哪吒监控</b> 一站式轻监控轻运维系统。支持系统状态、HTTP(SSL 证书变更、即将到期、到期)、TCP、Ping 监控报警，计划任务和在线终端。</p>

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -433,6 +433,12 @@ func handleTerminalTask(task *pb.Task) {
 	}
 	header := http.Header{}
 	header.Add("Secret", agentCliParam.ClientSecret)
+	// 目前只兼容Cloudflare验证
+	// 后续可能需要兼容更多的Cookie验证情况
+	if terminal.Cookie != "" {
+		cfCookie := fmt.Sprintf("CF_Authorization=%s", terminal.Cookie)
+		header.Add("Cookie", cfCookie)
+	}
 	conn, _, err := websocket.DefaultDialer.Dial(fmt.Sprintf("%s://%s/terminal/%s", protocol, terminal.Host, terminal.Session), header)
 	if err != nil {
 		println("Terminal 连接失败：", err)

--- a/cmd/dashboard/controller/common_page.go
+++ b/cmd/dashboard/controller/common_page.go
@@ -275,7 +275,6 @@ func (cp *commonPage) terminal(c *gin.Context) {
 			}, true)
 			return
 		}
-		var cloudflareCookies string
 		cloudflareCookies, _ = c.Cookie("CF_Authorization")
 		terminalData, _ := utils.Json.Marshal(&model.TerminalTask{
 			Host:    terminal.host,

--- a/cmd/dashboard/controller/common_page.go
+++ b/cmd/dashboard/controller/common_page.go
@@ -275,7 +275,7 @@ func (cp *commonPage) terminal(c *gin.Context) {
 			}, true)
 			return
 		}
-		cloudflareCookies, _ = c.Cookie("CF_Authorization")
+cloudflareCookies,  _ := c.Cookie("CF_Authorization")
 		terminalData, _ := utils.Json.Marshal(&model.TerminalTask{
 			Host:    terminal.host,
 			UseSSL:  terminal.useSSL,

--- a/cmd/dashboard/controller/common_page.go
+++ b/cmd/dashboard/controller/common_page.go
@@ -275,13 +275,14 @@ func (cp *commonPage) terminal(c *gin.Context) {
 			}, true)
 			return
 		}
-
+		var cloudflareCookies string
+		cloudflareCookies, _ = c.Cookie("CF_Authorization")
 		terminalData, _ := utils.Json.Marshal(&model.TerminalTask{
 			Host:    terminal.host,
 			UseSSL:  terminal.useSSL,
 			Session: terminalID,
+			Cookie:  cloudflareCookies,
 		})
-
 		if err := server.TaskStream.Send(&proto.Task{
 			Type: model.TaskTypeTerminal,
 			Data: string(terminalData),

--- a/model/monitor.go
+++ b/model/monitor.go
@@ -27,6 +27,8 @@ type TerminalTask struct {
 	UseSSL bool `json:"use_ssl,omitempty"`
 	// 会话标识
 	Session string `json:"session,omitempty"`
+	// Agent在连接Server时需要的额外Cookie信息
+	Cookie string `json:"cookie,omitempty"`
 }
 
 const (

--- a/service/singleton/singleton.go
+++ b/service/singleton/singleton.go
@@ -10,7 +10,7 @@ import (
 	"github.com/naiba/nezha/model"
 )
 
-var Version = "v0.12.18" // ！！记得修改 README 中的 badge 版本！！
+var Version = "v0.12.19" // ！！记得修改 README 中的 badge 版本！！
 
 var (
 	Conf  *model.Config


### PR DESCRIPTION
由于Web终端功能需要Agent主动连接用户浏览器传递的Host
在当前域名被Cloudflare Access保护的情况下 Agent将无法正常连接到面板websocket
因此面板将主动从用户的浏览器request中提取 CF_Authorization Cookie 并传递给Agent
Agent在连接时使用该Cookie绕过Cloudflare Access认证

需要重新编译dashboard与agent使得该功能生效