### PR TITLE
feat: 添加/修改通知方式时可选择不发送测试信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <br>
   <small><i>LOGO designed by <a href="https://xio.ng" target="_blank">熊大</a> .</i></small>
   <br><br>
-<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Dashboard%20image?label=Dash%20v0.12.21&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/github/v/release/naiba/nezha?color=brightgreen&label=Agent&style=for-the-badge&logo=github">&nbsp;<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Agent%20release?label=Agent%20CI&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/badge/Installer-v0.8.2-brightgreen?style=for-the-badge&logo=linux">
+<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Dashboard%20image?label=Dash%20v0.12.22&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/github/v/release/naiba/nezha?color=brightgreen&label=Agent&style=for-the-badge&logo=github">&nbsp;<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Agent%20release?label=Agent%20CI&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/badge/Installer-v0.8.2-brightgreen?style=for-the-badge&logo=linux">
   <br>
   <br>
   <p>:trollface: <b>哪吒监控</b> 一站式轻监控轻运维系统。支持系统状态、HTTP(SSL 证书变更、即将到期、到期)、TCP、Ping 监控报警，计划任务和在线终端。</p>

--- a/cmd/dashboard/controller/member_api.go
+++ b/cmd/dashboard/controller/member_api.go
@@ -395,6 +395,7 @@ type notificationForm struct {
 	RequestHeader string
 	RequestBody   string
 	VerifySSL     string
+	SkipCheck     string
 }
 
 func (ma *memberAPI) addOrEditNotification(c *gin.Context) {
@@ -416,7 +417,12 @@ func (ma *memberAPI) addOrEditNotification(c *gin.Context) {
 			Notification: &n,
 			Server:       nil,
 		}
-		err = ns.Send("这是测试消息")
+		// 勾选了跳过检查
+		if nf.SkipCheck == "on" {
+			err = nil
+		} else {
+			err = ns.Send("这是测试消息")
+		}
 	}
 	if err == nil {
 		// 保证Tag不为空

--- a/model/notification.go
+++ b/model/notification.go
@@ -175,6 +175,8 @@ func replaceParamsInString(s *Server, str string, message string, mod func(strin
 			str = strings.ReplaceAll(str, "#SERVER.LOAD1#", mod(fmt.Sprintf("%f", s.State.Load1)))
 			str = strings.ReplaceAll(str, "#SERVER.LOAD5#", mod(fmt.Sprintf("%f", s.State.Load5)))
 			str = strings.ReplaceAll(str, "#SERVER.LOAD15#", mod(fmt.Sprintf("%f", s.State.Load15)))
+			str = strings.ReplaceAll(str, "#SERVER.TCPCONNCOUNT#", mod(fmt.Sprintf("%d", s.State.TcpConnCount)))
+			str = strings.ReplaceAll(str, "#SERVER.UDPCONNCOUNT#", mod(fmt.Sprintf("%d", s.State.UdpConnCount)))
 		}
 	} else {
 		str = strings.ReplaceAll(str, "#NEZHA#", message)
@@ -192,6 +194,8 @@ func replaceParamsInString(s *Server, str string, message string, mod func(strin
 			str = strings.ReplaceAll(str, "#SERVER.LOAD1#", fmt.Sprintf("%f", s.State.Load1))
 			str = strings.ReplaceAll(str, "#SERVER.LOAD5#", fmt.Sprintf("%f", s.State.Load5))
 			str = strings.ReplaceAll(str, "#SERVER.LOAD15#", fmt.Sprintf("%f", s.State.Load15))
+			str = strings.ReplaceAll(str, "#SERVER.TCPCONNCOUNT#", fmt.Sprintf("%d", s.State.TcpConnCount))
+			str = strings.ReplaceAll(str, "#SERVER.UDPCONNCOUNT#", fmt.Sprintf("%d", s.State.UdpConnCount))
 		}
 	}
 	return str

--- a/resource/static/main.css
+++ b/resource/static/main.css
@@ -8,6 +8,7 @@ td {
   word-wrap: break-word;
   word-break: break-all;
 }
+
 .nb-container {
   padding-top: 75px;
   min-height: 100vh;

--- a/resource/static/main.css
+++ b/resource/static/main.css
@@ -4,6 +4,10 @@
   }
 }
 
+td {
+  word-wrap: break-word;
+  word-break: break-all;
+}
 .nb-container {
   padding-top: 75px;
   min-height: 100vh;

--- a/resource/static/main.js
+++ b/resource/static/main.js
@@ -154,6 +154,7 @@ function addOrEditNotification(notification) {
   } else {
     modal.find(".ui.nf-ssl.checkbox").checkbox("set unchecked");
   }
+    modal.find(".ui.nf-skip-check.checkbox").checkbox("set unchecked");
   showFormModal(
     ".notification.modal",
     "#notificationForm",

--- a/resource/static/main.js
+++ b/resource/static/main.js
@@ -154,7 +154,7 @@ function addOrEditNotification(notification) {
   } else {
     modal.find(".ui.nf-ssl.checkbox").checkbox("set unchecked");
   }
-    modal.find(".ui.nf-skip-check.checkbox").checkbox("set unchecked");
+  modal.find(".ui.nf-skip-check.checkbox").checkbox("set unchecked");
   showFormModal(
     ".notification.modal",
     "#notificationForm",

--- a/resource/template/common/footer.html
+++ b/resource/template/common/footer.html
@@ -9,7 +9,7 @@
 <script src="https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/semantic-ui/2.4.1/semantic.min.js"></script>
 <script src="/static/semantic-ui-alerts.min.js"></script>
 <script src="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-M/vue/2.6.12/vue.min.js"></script>
-<script src="/static/main.js?v20211105"></script>
+<script src="/static/main.js?v20220423"></script>
 </body>
 
 </html>

--- a/resource/template/common/header.html
+++ b/resource/template/common/header.html
@@ -9,7 +9,7 @@
     <title>{{.Title}}</title>
     <link rel="stylesheet" type="text/css" href="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-M/semantic-ui/2.4.1/semantic.min.css">
     <link rel="stylesheet" type="text/css" href="/static/semantic-ui-alerts.min.css">
-    <link rel="stylesheet" type="text/css" href="/static/main.css?v2021111109">
+    <link rel="stylesheet" type="text/css" href="/static/main.css?v2022042314">
     <link rel="shortcut icon" type="image/png" href="/static/logo.svg?v20210804" />
 </head>
 

--- a/resource/template/component/notification.html
+++ b/resource/template/component/notification.html
@@ -36,7 +36,7 @@
             </div>
             <div class="secret field">
                 <label>Body</label>
-                <textarea name="RequestBody" placeholder='{&#13;&#10;  "content":"#NEZHA#",&#13;&#10;  "ServerName":"#SERVER.NAME#",&#13;&#10;  "ServerIP":"#SERVER.IP#",&#13;&#10;  "CPU":"#SERVER.CPU#",&#13;&#10;  "MEM":"#SERVER.MEM#",&#13;&#10;  "SWAP":"#SERVER.SWAP#",&#13;&#10;  "DISK":"#SERVER.DISK#",&#13;&#10;  "NetInSpeed":"#SERVER.NETINSPEED#",&#13;&#10;  "NetOutSpeed":"#SERVER.NETOUTSPEED#",&#13;&#10;  "TransferIn":"#SERVER.TRANSFERIN#",&#13;&#10;  "TranferOut":"#SERVER.TRANSFEROUT#",&#13;&#10;  "Load1":"#SERVER.LOAD1#",&#13;&#10;  "Load5":"#SERVER.LOAD5#",&#13;&#10;  "Load15":"#SERVER.LOAD15#"&#13;&#10;}'></textarea>
+                <textarea name="RequestBody" placeholder='{&#13;&#10;  "content":"#NEZHA#",&#13;&#10;  "ServerName":"#SERVER.NAME#",&#13;&#10;  "ServerIP":"#SERVER.IP#",&#13;&#10;  "CPU":"#SERVER.CPU#",&#13;&#10;  "MEM":"#SERVER.MEM#",&#13;&#10;  "SWAP":"#SERVER.SWAP#",&#13;&#10;  "DISK":"#SERVER.DISK#",&#13;&#10;  "NetInSpeed":"#SERVER.NETINSPEED#",&#13;&#10;  "NetOutSpeed":"#SERVER.NETOUTSPEED#",&#13;&#10;  "TransferIn":"#SERVER.TRANSFERIN#",&#13;&#10;  "TranferOut":"#SERVER.TRANSFEROUT#",&#13;&#10;  "Load1":"#SERVER.LOAD1#",&#13;&#10;  "Load5":"#SERVER.LOAD5#",&#13;&#10;  "Load15":"#SERVER.LOAD15#"&#13;&#10;  "TCP_CONN_COUNT":"#SERVER.TCPCONNCOUNT"&#13;&#10;  "UDP_CONN_COUNT":"#SERVER.UDPCONNCOUNT"&#13;&#10;}'></textarea>
             </div>
             <div class="field">
                 <div class="ui nf-ssl checkbox">

--- a/resource/template/component/notification.html
+++ b/resource/template/component/notification.html
@@ -44,6 +44,12 @@
                     <label>验证SSL</label>
                 </div>
             </div>
+            <div class="field">
+                <div class="ui nf-skip-check checkbox">
+                    <input name="SkipCheck" type="checkbox" tabindex="0" class="hidden">
+                    <label>不发送测试信息</label>
+                </div>
+            </div>
         </form>
     </div>
     <div class="actions">

--- a/service/singleton/singleton.go
+++ b/service/singleton/singleton.go
@@ -12,7 +12,7 @@ import (
 	"github.com/naiba/nezha/pkg/utils"
 )
 
-var Version = "v0.12.21" // ！！记得修改 README 中的 badge 版本！！
+var Version = "v0.12.22" // ！！记得修改 README 中的 badge 版本！！
 
 var (
 	Conf  *model.Config


### PR DESCRIPTION
在通过通知的方式调用第三方WebAPI时
若该API请求体需要对有效的服务器状态指标（如IP）进行验证
可能会返回非200状态码并将阻止添加/修改该通知方式
因此在添加/修改通知方式界面添加一个checkbox
勾选后本次添加/修改将不发送测试信息

具体用例：
当希望通过IP变更通知提醒报警 将服务器IP添加至Cloudflare Access Rule 白名单时
需要先创建对应的通知方式进行相关API请求
若IP无效 Cloudflare API 会返回400状态码
此时无法保存该新建的通知方式
因此需要跳过测试信息发送