### PR TITLE
update: 服务器状态API增加上次汇报时间的unix时间戳

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <br>
   <small><i>LOGO designed by <a href="https://xio.ng" target="_blank">熊大</a> .</i></small>
   <br><br>
-<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Dashboard%20image?label=Dash%20v0.13.17&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/github/v/release/naiba/nezha?color=brightgreen&label=Agent&style=for-the-badge&logo=github">&nbsp;<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Agent%20release?label=Agent%20CI&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/badge/Installer-v0.10.2-brightgreen?style=for-the-badge&logo=linux">
+<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Dashboard%20image?label=Dash%20v0.13.18&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/github/v/release/naiba/nezha?color=brightgreen&label=Agent&style=for-the-badge&logo=github">&nbsp;<img src="https://img.shields.io/github/workflow/status/naiba/nezha/Agent%20release?label=Agent%20CI&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/badge/Installer-v0.10.2-brightgreen?style=for-the-badge&logo=linux">
   <br>
   <br>
   <p>:trollface: <b>Nezha Monitoring</b> self-hosted lightweight monitoring and operation system. Supports system status, HTTP (SSL certificate change, upcoming expiration, expiration), TCP, Ping <b>monitoring</b> and <b>alerting</b>, execute scheduled tasks and <b>web terminal</b>.</p>

--- a/service/singleton/api.go
+++ b/service/singleton/api.go
@@ -23,12 +23,13 @@ type CommonResponse struct {
 }
 
 type CommonServerInfo struct {
-	ID      uint64 `json:"id"`
-	Name    string `json:"name"`
-	Tag     string `json:"tag"`
-	IPV4    string `json:"ipv4"`
-	IPV6    string `json:"ipv6"`
-	ValidIP string `json:"valid_ip"`
+	ID         uint64 `json:"id"`
+	Name       string `json:"name"`
+	Tag        string `json:"tag"`
+	LastActive int64  `json:"last_active"`
+	IPV4       string `json:"ipv4"`
+	IPV6       string `json:"ipv6"`
+	ValidIP    string `json:"valid_ip"`
 }
 
 // StatusResponse 服务器状态子结构 包含服务器信息与状态信息
@@ -80,12 +81,13 @@ func (s *ServerAPIService) GetStatusByIDList(idList []uint64) *ServerStatusRespo
 		}
 		ipv4, ipv6, validIP := utils.SplitIPAddr(server.Host.IP)
 		info := CommonServerInfo{
-			ID:      server.ID,
-			Name:    server.Name,
-			Tag:     server.Tag,
-			IPV4:    ipv4,
-			IPV6:    ipv6,
-			ValidIP: validIP,
+			ID:         server.ID,
+			Name:       server.Name,
+			Tag:        server.Tag,
+			LastActive: server.LastActive.Unix(),
+			IPV4:       ipv4,
+			IPV6:       ipv6,
+			ValidIP:    validIP,
 		}
 		res.Result = append(res.Result, &StatusResponse{
 			CommonServerInfo: info,
@@ -119,12 +121,13 @@ func (s *ServerAPIService) GetAllStatus() *ServerStatusResponse {
 		}
 		ipv4, ipv6, validIP := utils.SplitIPAddr(host.IP)
 		info := CommonServerInfo{
-			ID:      v.ID,
-			Name:    v.Name,
-			Tag:     v.Tag,
-			IPV4:    ipv4,
-			IPV6:    ipv6,
-			ValidIP: validIP,
+			ID:         v.ID,
+			Name:       v.Name,
+			Tag:        v.Tag,
+			LastActive: v.LastActive.Unix(),
+			IPV4:       ipv4,
+			IPV6:       ipv6,
+			ValidIP:    validIP,
 		}
 		res.Result = append(res.Result, &StatusResponse{
 			CommonServerInfo: info,
@@ -153,12 +156,13 @@ func (s *ServerAPIService) GetListByTag(tag string) *ServerInfoResponse {
 		}
 		ipv4, ipv6, validIP := utils.SplitIPAddr(host.IP)
 		info := &CommonServerInfo{
-			ID:      v,
-			Name:    ServerList[v].Name,
-			Tag:     ServerList[v].Tag,
-			IPV4:    ipv4,
-			IPV6:    ipv6,
-			ValidIP: validIP,
+			ID:         v,
+			Name:       ServerList[v].Name,
+			Tag:        ServerList[v].Tag,
+			LastActive: ServerList[v].LastActive.Unix(),
+			IPV4:       ipv4,
+			IPV6:       ipv6,
+			ValidIP:    validIP,
 		}
 		res.Result = append(res.Result, info)
 	}
@@ -183,12 +187,13 @@ func (s *ServerAPIService) GetAllList() *ServerInfoResponse {
 		}
 		ipv4, ipv6, validIP := utils.SplitIPAddr(host.IP)
 		info := &CommonServerInfo{
-			ID:      v.ID,
-			Name:    v.Name,
-			Tag:     v.Tag,
-			IPV4:    ipv4,
-			IPV6:    ipv6,
-			ValidIP: validIP,
+			ID:         v.ID,
+			Name:       v.Name,
+			Tag:        v.Tag,
+			LastActive: v.LastActive.Unix(),
+			IPV4:       ipv4,
+			IPV6:       ipv6,
+			ValidIP:    validIP,
 		}
 		res.Result = append(res.Result, info)
 	}

--- a/service/singleton/singleton.go
+++ b/service/singleton/singleton.go
@@ -12,7 +12,7 @@ import (
 	"github.com/naiba/nezha/pkg/utils"
 )
 
-var Version = "v0.13.17" // ！！记得修改 README 中的 badge 版本！！
+var Version = "v0.13.18" // ！！记得修改 README 中的 badge 版本！！
 
 var (
 	Conf  *model.Config


### PR DESCRIPTION
last_active 可用于判断服务器当前是否在线
表示上次向面板汇报时间的unix时间戳

下面示例中的负数时间戳为（0000-00-00）
目前表示面板上线后该服务器从未汇报过状态
但不建议用正负性判断状态

`GET /api/v1/server/list`
```
{
    "code": 0,
    "message": "success",
    "result": [
        {
            "id": 1,
            "name": "t1",
            "tag": "222",
            "last_active": 1653014667,
            "ipv4": "1.1.1.1",
            "ipv6": "",
            "valid_ip": "1.1.1.1"
        },
        {
            "id": 2,
            "name": "22",
            "tag": "111",
            "last_active": -62135596800,
            "ipv4": "",
            "ipv6": "",
            "valid_ip": ""
        }
    ]
}
```
`GET /api/v1/server/details?id=&tag=`
```
{
    "code": 0,
    "message": "success",
    "result": [
        {
            "id": 1,
            "name": "t1",
            "tag": "222",
            "last_active": 1653015042,
            "ipv4": "1.1.1.1",
            "ipv6": "",
            "valid_ip": "1.1.1.1",
            "host": {
                "Platform": "darwin",
                "PlatformVersion": "12.3.1",
                "CPU": [
                    "Apple M1 Pro 1 Physical Core"
                ],
                "MemTotal": 17179869184,
                "DiskTotal": 2473496842240,
                "SwapTotal": 0,
                "Arch": "arm64",
                "Virtualization": "",
                "BootTime": 1652683962,
                "CountryCode": "hk",
                "Version": ""
            },
            "status": {
                "CPU": 17.330210772540017,
                "MemUsed": 14013841408,
                "SwapUsed": 0,
                "DiskUsed": 2335048912896,
                "NetInTransfer": 2710273234,
                "NetOutTransfer": 695454765,
                "NetInSpeed": 10806,
                "NetOutSpeed": 5303,
                "Uptime": 331080,
                "Load1": 5.23486328125,
                "Load5": 4.873046875,
                "Load15": 3.99267578125,
                "TcpConnCount": 195,
                "UdpConnCount": 70,
                "ProcessCount": 437
            }
        },
        {
            "id": 2,
            "name": "22",
            "tag": "111",
            "last_active": -62135596800,
            "ipv4": "",
            "ipv6": "",
            "valid_ip": "",
            "host": {
                "Platform": "",
                "PlatformVersion": "",
                "CPU": null,
                "MemTotal": 0,
                "DiskTotal": 0,
                "SwapTotal": 0,
                "Arch": "",
                "Virtualization": "",
                "BootTime": 0,
                "CountryCode": "",
                "Version": ""
            },
            "status": {
                "CPU": 0,
                "MemUsed": 0,
                "SwapUsed": 0,
                "DiskUsed": 0,
                "NetInTransfer": 0,
                "NetOutTransfer": 0,
                "NetInSpeed": 0,
                "NetOutSpeed": 0,
                "Uptime": 0,
                "Load1": 0,
                "Load5": 0,
                "Load15": 0,
                "TcpConnCount": 0,
                "UdpConnCount": 0,
                "ProcessCount": 0
            }
        }
    ]
}
```