### PR TITLE
fix: 更新导致创建日期归零

### DIFF
--- a/model/common.go
+++ b/model/common.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"gorm.io/gorm"
 	"time"
 )
 
@@ -9,10 +10,10 @@ const CtxKeyViewPasswordVerified = "ckvpv"
 const CacheKeyOauth2State = "p:a:state"
 
 type Common struct {
-	ID        uint64    `gorm:"primaryKey"`
-	CreatedAt time.Time `sql:"index"`
-	UpdatedAt time.Time
-	DeletedAt *time.Time `sql:"index"`
+	ID        uint64         `gorm:"primaryKey"`
+	CreatedAt time.Time      `gorm:"<-:create"`
+	UpdatedAt time.Time      `gorm:"autoUpdateTime"`
+	DeletedAt gorm.DeletedAt `gorm:"index"`
 }
 
 type Response struct {


### PR DESCRIPTION
## 复现
编辑过的服务器创建日期会清零
https://github.com/naiba/nezha/blob/master/cmd/dashboard/controller/member_api.go#L332
```log
2022/10/23 23:52:05 /home/owen/GolandProjects/nezha/cmd/dashboard/controller/member_api.go:332
[1.706ms] [rows:1] UPDATE `servers` SET `created_at`="0000-00-00 00:00:00",`updated_at`="2022-10-23 11:58:05.062",`deleted_at`=NULL,`name`="asd",`tag`="test",`secret`="test",`note`="test",`display_index`=0,`hide_for_guest`=false WHERE `id` = 1
```
![image](https://user-images.githubusercontent.com/24518597/197402493-8429d953-62f7-4684-8d36-e8e41e13c261.png)

## 问题
- gorm v2 Save默认保存所有值，即使值为空。[ref](https://github.com/go-gorm/gorm/issues/3739)
- 根据[gorm文档](https://gorm.io/zh_CN/docs/models.html#gorm-Model)更改标签
