### PR TITLE
fix: nameserver issue

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-echo -e "nameserver 127.0.0.11\nnameserver 8.8.4.4\nnameserver 223.5.5.5\n" > /etc/resolv.conf
+printf "nameserver 127.0.0.11\nnameserver 8.8.4.4\nnameserver 223.5.5.5\n" > /etc/resolv.conf
 /dashboard/app


### PR DESCRIPTION
sh下echo -e实际会输出带有"-e"的首行
使得首个nameserver无效

```shell
sh-3.2$ echo -e "nameserver 127.0.0.11\nnameserver 8.8.4.4\nnameserver 223.5.5.5\n" > test.txt
sh-3.2$ cat test.txt
-e nameserver 127.0.0.11
nameserver 8.8.4.4
nameserver 223.5.5.5
```

改用printf后

```shell
sh-3.2$ printf "nameserver 127.0.0.11\nnameserver 8.8.4.4\nnameserver 223.5.5.5\n" > test.txt
sh-3.2$ cat test.txt
nameserver 127.0.0.11
nameserver 8.8.4.4
nameserver 223.5.5.5
```

详情见下面链接
https://unix.stackexchange.com/questions/65803/why-is-printf-better-than-echo