### PR TITLE
fix: 部分环境下启动时间锁定在1970年的问题

### DIFF
--- a/cmd/agent/monitor/monitor.go
+++ b/cmd/agent/monitor/monitor.go
@@ -66,9 +66,7 @@ func GetHost(agentConfig *model.AgentConfig) *model.Host {
 		swapMemTotal = mv.SwapTotal
 	}
 
-	if cachedBootTime.IsZero() {
-		cachedBootTime = time.Unix(int64(hi.BootTime), 0)
-	}
+	cachedBootTime = time.Unix(int64(hi.BootTime), 0)
 
 	return &model.Host{
 		Platform:        hi.Platform,


### PR DESCRIPTION
常规状态汇报时使用缓存的bootTime
但是如果这个缓存的bootTime不为0
（部分环境存在系统启动时间错误的问题，需要等待网络时间同步服务更新正确的时间）
那么每10分钟的系统信息更新不会更新这个缓存

就导致虽然第10分钟那一次汇报会给面板上报正确的时间
但是下一次常规汇报又回回到错误的时间

每10分钟进行一次的unix时间戳转换与boottime读取并不会占用过多资源。
因此本pr将不再判断bootTime不为0，总是向缓存写入最新的数据
