### PR TITLE
效仿中文版shell给英文版shell增加中国IP判断

### DIFF
--- a/script/install_en.sh
+++ b/script/install_en.sh
@@ -43,11 +43,41 @@ pre_check() {
         os_arch="riscv64"
     fi
     
-    GITHUB_RAW_URL="raw.githubusercontent.com/naiba/nezha/master"
-    GITHUB_URL="github.com"
-    Get_Docker_URL="get.docker.com"
-    Get_Docker_Argu=" "
-    Docker_IMG="ghcr.io\/naiba\/nezha-dashboard"
+    ## China_IP
+    if [[ -z "${CN}" ]]; then
+        if [[ $(curl -m 10 -s https://ipapi.co/json | grep 'China') != "" ]]; then
+            echo "According to the information provided by ipapi.co, the current IP may be in China"
+            read -e -r -p "Is the installation done with a Chinese Mirror? [Y/n] " input
+            case $input in
+                [yY][eE][sS] | [yY])
+                    echo "Use China Mirror"
+                    CN=true
+                ;;
+                
+                [nN][oO] | [nN])
+                    echo "No Use China Mirror"
+                ;;
+                *)
+                    echo "Use China Mirror"
+                    CN=true
+                ;;
+            esac
+        fi
+    fi
+    
+    if [[ -z "${CN}" ]]; then
+        GITHUB_RAW_URL="raw.githubusercontent.com/naiba/nezha/master"
+        GITHUB_URL="github.com"
+        Get_Docker_URL="get.docker.com"
+        Get_Docker_Argu=" "
+        Docker_IMG="ghcr.io\/naiba\/nezha-dashboard"
+    else
+        GITHUB_RAW_URL="cdn.jsdelivr.net/gh/naiba/nezha@master"
+        GITHUB_URL="dn-dao-github-mirror.daocloud.io"
+        Get_Docker_URL="get.daocloud.io/docker"
+        Get_Docker_Argu=" -s docker --mirror Aliyun"
+        Docker_IMG="registry.cn-shanghai.aliyuncs.com\/naibahq\/nezha-dashboard"
+    fi
 }
 
 confirm() {

--- a/script/install_en.sh
+++ b/script/install_en.sh
@@ -50,36 +50,33 @@ pre_check() {
             read -e -r -p "Is the installation done with a Chinese Mirror? [Y/n] " input
             case $input in
                 [yY][eE][sS] | [yY])
-                    echo "Use China Mirror"
+                    echo "Use Chinese Mirror"
                     CN=true
                 ;;
                 
                 [nN][oO] | [nN])
-                    echo "No Use China Mirror"
+                    echo "No Use Chinese Mirror"
                 ;;
                 *)
-                    echo "No Use China Mirror"
+                    echo "No Use Chinese Mirror"
                 ;;
             esac
         fi
     fi
     
-    if [[ -n "${CN}" && "${CN}" == true ]]; then
-        # Use Chinese mirrors
-        GITHUB_RAW_URL="cdn.jsdelivr.net/gh/naiba/nezha@master"
-        GITHUB_URL="dn-dao-github-mirror.daocloud.io"
-        Get_Docker_URL="get.daocloud.io/docker"
-        Get_Docker_Argu=" -s docker --mirror Aliyun"
-        Docker_IMG="registry.cn-shanghai.aliyuncs.com\/naibahq\/nezha-dashboard"
-    else
-        # Use default
+    if [[ -z "${CN}" ]]; then
         GITHUB_RAW_URL="raw.githubusercontent.com/naiba/nezha/master"
         GITHUB_URL="github.com"
         Get_Docker_URL="get.docker.com"
         Get_Docker_Argu=" "
         Docker_IMG="ghcr.io\/naiba\/nezha-dashboard"
+    else
+        GITHUB_RAW_URL="cdn.jsdelivr.net/gh/naiba/nezha@master"
+        GITHUB_URL="dn-dao-github-mirror.daocloud.io"
+        Get_Docker_URL="get.daocloud.io/docker"
+        Get_Docker_Argu=" -s docker --mirror Aliyun"
+        Docker_IMG="registry.cn-shanghai.aliyuncs.com\/naibahq\/nezha-dashboard"
     fi
-
 }
 
 confirm() {

--- a/script/install_en.sh
+++ b/script/install_en.sh
@@ -58,8 +58,7 @@ pre_check() {
                     echo "No Use China Mirror"
                 ;;
                 *)
-                    echo "Use China Mirror"
-                    CN=true
+                    echo "No Use China Mirror"
                 ;;
             esac
         fi

--- a/script/install_en.sh
+++ b/script/install_en.sh
@@ -64,19 +64,22 @@ pre_check() {
         fi
     fi
     
-    if [[ -z "${CN}" ]]; then
-        GITHUB_RAW_URL="raw.githubusercontent.com/naiba/nezha/master"
-        GITHUB_URL="github.com"
-        Get_Docker_URL="get.docker.com"
-        Get_Docker_Argu=" "
-        Docker_IMG="ghcr.io\/naiba\/nezha-dashboard"
-    else
+    if [[ -n "${CN}" && "${CN}" == true ]]; then
+        # Use Chinese mirrors
         GITHUB_RAW_URL="cdn.jsdelivr.net/gh/naiba/nezha@master"
         GITHUB_URL="dn-dao-github-mirror.daocloud.io"
         Get_Docker_URL="get.daocloud.io/docker"
         Get_Docker_Argu=" -s docker --mirror Aliyun"
         Docker_IMG="registry.cn-shanghai.aliyuncs.com\/naibahq\/nezha-dashboard"
+    else
+        # Use default
+        GITHUB_RAW_URL="raw.githubusercontent.com/naiba/nezha/master"
+        GITHUB_URL="github.com"
+        Get_Docker_URL="get.docker.com"
+        Get_Docker_Argu=" "
+        Docker_IMG="ghcr.io\/naiba\/nezha-dashboard"
     fi
+
 }
 
 confirm() {


### PR DESCRIPTION
效仿中文版shell给英文版shell增加中国IP判断

缘由：个人使用英文版的面板，但有插探针到中国地区服务器的需求，此时哪吒的一键脚本使用的```install_en.sh```没有配置中国IP检测，导致无法安装监控端。

修改部分：效仿中文版shell给英文版shell增加中国IP判断，但默认如果检测不到是中国IP时不使用中国镜像仍使用原始的Github链接，仅这部分不同。