### PR TITLE
Feat: 服务监控支持触发任务执行

### DIFF
--- a/cmd/dashboard/controller/member_api.go
+++ b/cmd/dashboard/controller/member_api.go
@@ -396,18 +396,21 @@ func (ma *memberAPI) addOrEditServer(c *gin.Context) {
 }
 
 type monitorForm struct {
-	ID              uint64
-	Name            string
-	Target          string
-	Type            uint8
-	Cover           uint8
-	Notify          string
-	NotificationTag string
-	SkipServersRaw  string
-	Duration        uint64
-	MinLatency      float32
-	MaxLatency      float32
-	LatencyNotify   string
+	ID                     uint64
+	Name                   string
+	Target                 string
+	Type                   uint8
+	Cover                  uint8
+	Notify                 string
+	NotificationTag        string
+	SkipServersRaw         string
+	Duration               uint64
+	MinLatency             float32
+	MaxLatency             float32
+	LatencyNotify          string
+	EnableTriggerTask      string
+	FailTriggerTasksRaw    string
+	RecoverTriggerTasksRaw string
 }
 
 func (ma *memberAPI) addOrEditMonitor(c *gin.Context) {
@@ -427,12 +430,21 @@ func (ma *memberAPI) addOrEditMonitor(c *gin.Context) {
 		m.LatencyNotify = mf.LatencyNotify == "on"
 		m.MinLatency = mf.MinLatency
 		m.MaxLatency = mf.MaxLatency
+		m.EnableTriggerTask = mf.EnableTriggerTask == "on"
+		m.RecoverTriggerTasksRaw = mf.RecoverTriggerTasksRaw
+		m.FailTriggerTasksRaw = mf.FailTriggerTasksRaw
 		err = m.InitSkipServers()
 	}
 	if err == nil {
 		// 保证NotificationTag不为空
 		if m.NotificationTag == "" {
 			m.NotificationTag = "default"
+		}
+		if err == nil {
+			err = utils.Json.Unmarshal([]byte(mf.FailTriggerTasksRaw), &m.FailTriggerTasks)
+		}
+		if err == nil {
+			err = utils.Json.Unmarshal([]byte(mf.RecoverTriggerTasksRaw), &m.RecoverTriggerTasks)
 		}
 		if m.ID == 0 {
 			err = singleton.DB.Create(&m).Error

--- a/resource/l10n/zh-CN.toml
+++ b/resource/l10n/zh-CN.toml
@@ -184,6 +184,9 @@ other = "始终触发"
 [ModeOnetimeTrigger]
 other = "单次触发"
 
+[EnableTriggerTask]
+other = "启用触发任务"
+
 [FailTriggerTasks]
 other = "故障时触发任务"
 

--- a/resource/static/main.js
+++ b/resource/static/main.js
@@ -330,22 +330,61 @@ function addOrEditMonitor(monitor) {
   modal.find("a.ui.label.visible").each((i, el) => {
     el.remove();
   });
+  if (monitor && monitor.EnableTriggerTask) {
+    modal.find(".ui.nb-EnableTriggerTask.checkbox").checkbox("set checked");
+  } else {
+    modal.find(".ui.nb-EnableTriggerTask.checkbox").checkbox("set unchecked");
+  }
   var servers;
+  var failTriggerTasks;
+  var recoverTriggerTasks;
   if (monitor) {
     servers = monitor.SkipServersRaw;
     const serverList = JSON.parse(servers || "[]");
-    const node = modal.find("i.dropdown.icon");
+    const node = modal.find("i.dropdown.icon.specificServer");
     for (let i = 0; i < serverList.length; i++) {
       node.after(
-        '<a class="ui label transition visible" data-value="' +
-        serverList[i] +
-        '" style="display: inline-block !important;">ID:' +
-        serverList[i] +
-        '<i class="delete icon"></i></a>'
+          '<a class="ui label transition visible" data-value="' +
+          serverList[i] +
+          '" style="display: inline-block !important;">ID:' +
+          serverList[i] +
+          '<i class="delete icon"></i></a>'
+      );
+    }
+
+    failTriggerTasks = monitor.FailTriggerTasksRaw;
+    recoverTriggerTasks = monitor.RecoverTriggerTasksRaw;
+    const failTriggerTasksList = JSON.parse(failTriggerTasks || "[]");
+    const recoverTriggerTasksList = JSON.parse(recoverTriggerTasks || "[]");
+    const node1 = modal.find("i.dropdown.icon.failTask");
+    const node2 = modal.find("i.dropdown.icon.recoverTask");
+    for (let i = 0; i < failTriggerTasksList.length; i++) {
+      node1.after(
+          '<a class="ui label transition visible" data-value="' +
+          failTriggerTasksList[i] +
+          '" style="display: inline-block !important;">ID:' +
+          failTriggerTasksList[i] +
+          '<i class="delete icon"></i></a>'
+      );
+    }
+    for (let i = 0; i < recoverTriggerTasksList.length; i++) {
+      node2.after(
+          '<a class="ui label transition visible" data-value="' +
+          recoverTriggerTasksList[i] +
+          '" style="display: inline-block !important;">ID:' +
+          recoverTriggerTasksList[i] +
+          '<i class="delete icon"></i></a>'
       );
     }
   }
-  modal
+modal
+    .find("input[name=FailTriggerTasksRaw]")
+    .val(monitor ? "[]," + failTriggerTasks.substr(1, failTriggerTasks.length - 2) : "[]");
+modal
+    .find("input[name=RecoverTriggerTasksRaw]")
+    .val(monitor ? "[]," + recoverTriggerTasks.substr(1, recoverTriggerTasks.length - 2) : "[]");
+
+modal
     .find("input[name=SkipServersRaw]")
     .val(monitor ? "[]," + servers.substr(1, servers.length - 2) : "[]");
   showFormModal(".monitor.modal", "#monitorForm", "/api/monitor");

--- a/resource/template/component/monitor.html
+++ b/resource/template/component/monitor.html
@@ -39,7 +39,7 @@
         <label>{{tr "SpecificServers"}}</label>
         <div class="ui fluid multiple servers search selection dropdown">
           <input type="hidden" name="SkipServersRaw" />
-          <i class="dropdown icon"></i>
+          <i class="dropdown icon specificServer"></i>
           <div class="default text">{{tr "EnterIdAndNameToSearch"}}</div>
           <div class="menu"></div>
         </div>
@@ -68,6 +68,33 @@
           <label>{{tr "EnableLatencyNotification"}}</label>
         </div>
       </div>
+
+      <div class="field">
+        <div class="ui nb-EnableTriggerTask checkbox">
+          <input name="EnableTriggerTask" type="checkbox" tabindex="0" class="hidden" />
+          <label>{{tr "EnableTriggerTask"}}</label>
+        </div>
+      </div>
+
+      <div class="field">
+        <label>{{tr "FailTriggerTasks"}}</label>
+        <div class="ui fluid multiple tasks search selection dropdown">
+          <input type="hidden" name="FailTriggerTasksRaw">
+          <i class="dropdown icon failTask"></i>
+          <div class="default text">{{tr "EnterIdAndNameToSearch"}}</div>
+          <div class="menu"></div>
+        </div>
+      </div>
+      <div class="field">
+        <label>{{tr "RecoverTriggerTasks"}}</label>
+        <div class="ui fluid multiple tasks search selection dropdown">
+          <input type="hidden" name="RecoverTriggerTasksRaw">
+          <i class="dropdown icon recoverTask"></i>
+          <div class="default text">{{tr "EnterIdAndNameToSearch"}}</div>
+          <div class="menu"></div>
+        </div>
+      </div>
+
     </form>
     <div class="ui warning message">
       <p>

--- a/resource/template/dashboard-default/monitor.html
+++ b/resource/template/dashboard-default/monitor.html
@@ -22,6 +22,9 @@
           <th>{{tr "NotificationMethodGroup"}}</th>
           <th>{{tr "FailureNotification"}}</th>
           <th>{{tr "LatencyNotification"}}</th>
+          <th>{{tr "EnableTriggerTask"}}</th>
+          <th>{{tr "FailTriggerTasks"}}</th>
+          <th>{{tr "RecoverTriggerTasks"}}</th>
           <th>{{tr "Administration"}}</th>
         </tr>
       </thead>
@@ -41,6 +44,9 @@
           <td>{{$monitor.NotificationTag}}</td>
           <td>{{$monitor.Notify}}</td>
           <td>{{$monitor.LatencyNotify}}</td>
+          <td>{{$monitor.EnableTriggerTask}}</td>
+          <td>{{$monitor.FailTriggerTasksRaw}}</td>
+          <td>{{$monitor.RecoverTriggerTasksRaw}}</td>
           <td>
             <div class="ui mini icon buttons">
               <button class="ui button" onclick="addOrEditMonitor({{$monitor}})">

--- a/service/singleton/alertsentinel.go
+++ b/service/singleton/alertsentinel.go
@@ -165,8 +165,8 @@ func checkStatus() {
 					go SendTriggerTasks(alert.FailTriggerTasks, curServer.ID)
 					go SendNotification(alert.NotificationTag, message, NotificationMuteLabel.ServerIncident(server.ID, alert.ID), &curServer)
 					// 清除恢复通知的静音缓存
-					resolvedMuteLabel := fmt.Sprintf("%s:%s", *NotificationMuteLabel.ServerIncidentResolved(server.ID, alert.ID), alert.NotificationTag)
-					Cache.Delete(resolvedMuteLabel)
+					resolvedMuteLabel := NotificationMuteLabel.AppendNotificationTag(NotificationMuteLabel.ServerIncidentResolved(server.ID, alert.ID), alert.NotificationTag)
+					Cache.Delete(*resolvedMuteLabel)
 				}
 			} else {
 				// 本次通过检查但上一次的状态为失败，则发送恢复通知
@@ -177,8 +177,8 @@ func checkStatus() {
 					go SendTriggerTasks(alert.RecoverTriggerTasks, curServer.ID)
 					go SendNotification(alert.NotificationTag, message, NotificationMuteLabel.ServerIncidentResolved(server.ID, alert.ID), &curServer)
 					// 清除失败通知的静音缓存
-					incidentMuteLabel := fmt.Sprintf("%s:%s", *NotificationMuteLabel.ServerIncident(server.ID, alert.ID), alert.NotificationTag)
-					Cache.Delete(incidentMuteLabel)
+					incidentMuteLabel := NotificationMuteLabel.AppendNotificationTag(NotificationMuteLabel.ServerIncident(server.ID, alert.ID), alert.NotificationTag)
+					Cache.Delete(*incidentMuteLabel)
 				}
 				alertsPrevState[alert.ID][server.ID] = _RuleCheckPass
 			}

--- a/service/singleton/alertsentinel.go
+++ b/service/singleton/alertsentinel.go
@@ -164,6 +164,9 @@ func checkStatus() {
 					}), server.Name, IPDesensitize(server.Host.IP), alert.Name)
 					go SendTriggerTasks(alert.FailTriggerTasks, curServer.ID)
 					go SendNotification(alert.NotificationTag, message, NotificationMuteLabel.ServerIncident(server.ID, alert.ID), &curServer)
+					// 清除恢复通知的静音缓存
+					resolvedMuteLabel := fmt.Sprintf("%s:%s", *NotificationMuteLabel.ServerIncidentResolved(server.ID, alert.ID), alert.NotificationTag)
+					Cache.Delete(resolvedMuteLabel)
 				}
 			} else {
 				// 本次通过检查但上一次的状态为失败，则发送恢复通知
@@ -173,6 +176,9 @@ func checkStatus() {
 					}), server.Name, IPDesensitize(server.Host.IP), alert.Name)
 					go SendTriggerTasks(alert.RecoverTriggerTasks, curServer.ID)
 					go SendNotification(alert.NotificationTag, message, NotificationMuteLabel.ServerIncidentResolved(server.ID, alert.ID), &curServer)
+					// 清除失败通知的静音缓存
+					incidentMuteLabel := fmt.Sprintf("%s:%s", *NotificationMuteLabel.ServerIncident(server.ID, alert.ID), alert.NotificationTag)
+					Cache.Delete(incidentMuteLabel)
 				}
 				alertsPrevState[alert.ID][server.ID] = _RuleCheckPass
 			}

--- a/service/singleton/notification.go
+++ b/service/singleton/notification.go
@@ -106,7 +106,7 @@ func OnDeleteNotification(id uint64) {
 func SendNotification(notificationTag string, desc string, muteLabel *string, ext ...*model.Server) {
 	if muteLabel != nil {
 		// 将通知方式组名称加入静音标志
-		muteLabel := fmt.Sprintf("%s:%s", *muteLabel, notificationTag)
+		muteLabel := *NotificationMuteLabel.AppendNotificationTag(muteLabel, notificationTag)
 		// 通知防骚扰策略
 		var flag bool
 		if cacheN, has := Cache.Get(muteLabel); has {
@@ -177,6 +177,11 @@ func (_NotificationMuteLabel) ServerIncident(alertId uint64, serverId uint64) *s
 func (_NotificationMuteLabel) ServerIncidentResolved(alertId uint64, serverId uint64) *string {
 	label := fmt.Sprintf("bf::seir-%d-%d", alertId, serverId)
 	return &label
+}
+
+func (_NotificationMuteLabel) AppendNotificationTag(label *string, notificationTag string) *string {
+	newLabel := fmt.Sprintf("%s:%s", *label, notificationTag)
+	return &newLabel
 }
 
 func (_NotificationMuteLabel) ServiceLatencyMin(serviceId uint64) *string {


### PR DESCRIPTION
-  最近30点位服务状态由「正常」变更为「低可用」「故障」时触发故障任务
-  最近30点位服务状态由「低可用」「故障」变更为「正常」时触发恢复任务


对于「由触发服务器执行」的任务
触发服务器为 使服务状态发生变更的上报 所使用的服务器
例如：
服务器A的任务上报使得最近30点位服务状态由「正常」变为「低可用」
则触发故障任务，触发服务器为「服务器A」

