### PR TITLE
服务状态变更时清除静音缓存

### DIFF
--- a/service/rpc/nezha.go
+++ b/service/rpc/nezha.go
@@ -118,12 +118,16 @@ func (s *NezhaHandler) ReportSystemInfo(c context.Context, r *pb.Host) (*pb.Rece
 		host.IP != "" &&
 		singleton.ServerList[clientID].Host.IP != host.IP {
 
-		singleton.SendNotification(singleton.Conf.IPChangeNotificationTag, fmt.Sprintf(
-			"[%s] %s, %s => %s",
-			singleton.Localizer.MustLocalize(&i18n.LocalizeConfig{
-				MessageID: "IPChanged",
-			}),
-			singleton.ServerList[clientID].Name, singleton.IPDesensitize(singleton.ServerList[clientID].Host.IP), singleton.IPDesensitize(host.IP)), singleton.NotificationMuteLabel.IPChanged(clientID), nil)
+		singleton.SendNotification(singleton.Conf.IPChangeNotificationTag,
+			fmt.Sprintf(
+				"[%s] %s, %s => %s",
+				singleton.Localizer.MustLocalize(&i18n.LocalizeConfig{
+					MessageID: "IPChanged",
+				}),
+				singleton.ServerList[clientID].Name, singleton.IPDesensitize(singleton.ServerList[clientID].Host.IP),
+				singleton.IPDesensitize(host.IP),
+			),
+			nil)
 	}
 
 	// 判断是否是机器重启，如果是机器重启要录入最后记录的流量里面

--- a/service/singleton/alertsentinel.go
+++ b/service/singleton/alertsentinel.go
@@ -165,8 +165,7 @@ func checkStatus() {
 					go SendTriggerTasks(alert.FailTriggerTasks, curServer.ID)
 					go SendNotification(alert.NotificationTag, message, NotificationMuteLabel.ServerIncident(server.ID, alert.ID), &curServer)
 					// 清除恢复通知的静音缓存
-					resolvedMuteLabel := NotificationMuteLabel.AppendNotificationTag(NotificationMuteLabel.ServerIncidentResolved(server.ID, alert.ID), alert.NotificationTag)
-					Cache.Delete(*resolvedMuteLabel)
+					UnMuteNotification(alert.NotificationTag, NotificationMuteLabel.ServerIncidentResolved(server.ID, alert.ID))
 				}
 			} else {
 				// 本次通过检查但上一次的状态为失败，则发送恢复通知
@@ -177,8 +176,7 @@ func checkStatus() {
 					go SendTriggerTasks(alert.RecoverTriggerTasks, curServer.ID)
 					go SendNotification(alert.NotificationTag, message, NotificationMuteLabel.ServerIncidentResolved(server.ID, alert.ID), &curServer)
 					// 清除失败通知的静音缓存
-					incidentMuteLabel := NotificationMuteLabel.AppendNotificationTag(NotificationMuteLabel.ServerIncident(server.ID, alert.ID), alert.NotificationTag)
-					Cache.Delete(*incidentMuteLabel)
+					UnMuteNotification(alert.NotificationTag, NotificationMuteLabel.ServerIncident(server.ID, alert.ID))
 				}
 				alertsPrevState[alert.ID][server.ID] = _RuleCheckPass
 			}

--- a/service/singleton/notification.go
+++ b/service/singleton/notification.go
@@ -102,6 +102,11 @@ func OnDeleteNotification(id uint64) {
 	delete(NotificationIDToTag, id)
 }
 
+func UnMuteNotification(notificationTag string, muteLabel *string) {
+	fullMuteLabel := *NotificationMuteLabel.AppendNotificationTag(muteLabel, notificationTag)
+	Cache.Delete(fullMuteLabel)
+}
+
 // SendNotification 向指定的通知方式组的所有通知方式发送通知
 func SendNotification(notificationTag string, desc string, muteLabel *string, ext ...*model.Server) {
 	if muteLabel != nil {
@@ -199,7 +204,7 @@ func (_NotificationMuteLabel) ServiceStateChanged(serviceId uint64) *string {
 	return &label
 }
 
-func (_NotificationMuteLabel) ServiceSSL(serviceId uint64) *string {
-	label := fmt.Sprintf("bf::sssl-%d", serviceId)
+func (_NotificationMuteLabel) ServiceSSL(serviceId uint64, extraInfo string) *string {
+	label := fmt.Sprintf("bf::sssl-%d-%s", serviceId, extraInfo)
 	return &label
 }

--- a/service/singleton/servicesentinel.go
+++ b/service/singleton/servicesentinel.go
@@ -416,7 +416,7 @@ func (ss *ServiceSentinel) worker() {
 			ss.lastStatus[mh.GetId()] = stateCode
 
 			// 判断是否需要发送通知
-			isNeedSendNotification := ss.monitors[mh.GetId()].Notify && lastStatus != 0
+			isNeedSendNotification := ss.monitors[mh.GetId()].Notify && (lastStatus != 0 || stateCode == StatusDown)
 			if isNeedSendNotification {
 				ServerLock.RLock()
 


### PR DESCRIPTION
同 #288 对服务器监控的静音缓存改动， 服务状态变更时清除静音缓存，防止状态变更通知无法发送

解决下面这个问题
```
2023/06/18 04:05:09 在线率 100
2023/06/18 04:05:10 在线率 83
2023/06/18 04:05:10 NEZHA>> 尝试通知 tg1
2023/06/18 04:05:10 NEZHA>> 向  tg1  发送通知成功：
2023/06/18 04:05:11 在线率 71
2023/06/18 04:05:11 NEZHA>> 静音的重复通知： [故障] cc Reporter: 测试1, Error: Get "http://127.0.0.1:17878": dial tcp 127.0.0.1:17878: connect: connection refused bf::ssc-1:1
2023/06/18 04:05:14 在线率 80
2023/06/18 04:05:14 NEZHA>> 静音的重复通知： [故障] cc Reporter: 测试2, Error:  bf::ssc-1:1
2023/06/18 04:05:15 在线率 81
2023/06/18 04:05:15 NEZHA>> 静音的重复通知： [低可用] cc Reporter: 测试1, Error:  bf::ssc-1:1
2023/06/18 04:05:40 在线率 96
2023/06/18 04:05:40 NEZHA>> 静音的重复通知： [良好] cc Reporter: 测试2, Error:  bf::ssc-1:1
```


修复后：
```
2023/06/18 04:10:39 在线率 100
2023/06/18 04:10:40 在线率 75
2023/06/18 04:10:40 NEZHA>> 尝试通知 tg1
2023/06/18 04:10:40 NEZHA>> 向  tg1  发送通知成功：
2023/06/18 04:10:41 在线率 80
2023/06/18 04:10:41 NEZHA>> 静音的重复通知： [故障] cc Reporter: 测试1, Error:  bf::ssc-1:1
2023/06/18 04:10:42 在线率 83
2023/06/18 04:10:42 NEZHA>> 尝试通知 tg1
2023/06/18 04:10:42 NEZHA>> 向  tg1  发送通知成功：
2023/06/18 04:11:01 在线率 96
2023/06/18 04:11:01 NEZHA>> 尝试通知 tg1
2023/06/18 04:11:01 NEZHA>> 向  tg1  发送通知成功：
```