### PR TITLE
Fix: get.daocloud.io 503

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -74,7 +74,7 @@ pre_check() {
     else
         GITHUB_RAW_URL="jihulab.com/nezha/dashboard/-/raw/master"
         GITHUB_URL="dn-dao-github-mirror.daocloud.io"
-        Get_Docker_URL="get.daocloud.io/docker"
+        Get_Docker_URL="get.docker.com"
         Get_Docker_Argu=" -s docker --mirror Aliyun"
         Docker_IMG="registry.cn-shanghai.aliyuncs.com\/naibahq\/nezha-dashboard"
     fi


### PR DESCRIPTION
get.daocloud.io is down. Use origin url instead.
![image](https://github.com/naiba/nezha/assets/44471469/35a323a5-c601-4fa4-a321-ff0b2f4be28b)
