### PR TITLE
Fix Coroutine Leaks and Proxy Handling in http.Client

### DIFF
--- a/model/alertrule.go
+++ b/model/alertrule.go
@@ -85,13 +85,13 @@ func (r *AlertRule) Snapshot(cycleTransferStats *CycleTransferStats, server *Ser
 
 // Check 传入包含当前报警规则下所有type检查结果的空接口 返回报警持续时间与是否通过报警检查(通过则返回true)
 func (r *AlertRule) Check(points [][]interface{}) (int, bool) {
-	var max int   // 报警持续时间
-	var count int // 检查未通过的个数
+	var maxNum int // 报警持续时间
+	var count int  // 检查未通过的个数
 	for i := 0; i < len(r.Rules); i++ {
 		if r.Rules[i].IsTransferDurationRule() {
 			// 循环区间流量报警
-			if max < 1 {
-				max = 1
+			if maxNum < 1 {
+				maxNum = 1
 			}
 			for j := len(points[i]) - 1; j >= 0; j-- {
 				if points[i][j] != nil {
@@ -104,8 +104,8 @@ func (r *AlertRule) Check(points [][]interface{}) (int, bool) {
 			total := 0.0
 			fail := 0.0
 			num := int(r.Rules[i].Duration)
-			if num > max {
-				max = num
+			if num > maxNum {
+				maxNum = num
 			}
 			if len(points) < num {
 				continue
@@ -124,5 +124,5 @@ func (r *AlertRule) Check(points [][]interface{}) (int, bool) {
 		}
 	}
 	// 仅当所有检查均未通过时 返回false
-	return max, count != len(r.Rules)
+	return maxNum, count != len(r.Rules)
 }

--- a/model/notification.go
+++ b/model/notification.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -117,11 +116,14 @@ func (ns *NotificationServerBundle) Send(message string) error {
 		verifySSL = true
 	}
 
-	transCfg := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: verifySSL},
+	var client *http.Client
+
+	if verifySSL {
+		client = utils.HttpClient
+	} else {
+		client = utils.HttpClientSkipTlsVerify
 	}
 
-	client := &http.Client{Transport: transCfg, Timeout: time.Minute * 10}
 	reqBody, err := ns.reqBody(message)
 	if err != nil {
 		return err

--- a/model/notification.go
+++ b/model/notification.go
@@ -149,13 +149,15 @@ func (ns *NotificationServerBundle) Send(message string) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		defer func() {
-			_ = resp.Body.Close()
-		}()
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("%d@%s %s", resp.StatusCode, resp.Status, string(body))
+	} else {
+		_, _ = io.Copy(io.Discard, resp.Body)
 	}
 
 	return nil

--- a/pkg/utils/http.go
+++ b/pkg/utils/http.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"crypto/tls"
+	"net/http"
+	"time"
+)
+
+var (
+	HttpClientSkipTlsVerify *http.Client
+	HttpClient              *http.Client
+)
+
+func init() {
+	HttpClientSkipTlsVerify = httpClient(_httpClient{
+		Transport: httpTransport(_httpTransport{
+			VerifySSL: true,
+		}),
+	})
+	HttpClient = httpClient(_httpClient{
+		Transport: httpTransport(_httpTransport{
+			VerifySSL: false,
+		}),
+	})
+}
+
+type _httpTransport struct {
+	VerifySSL bool
+}
+
+func httpTransport(conf _httpTransport) *http.Transport {
+	return &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: conf.VerifySSL},
+	}
+}
+
+type _httpClient struct {
+	Transport *http.Transport
+}
+
+func httpClient(conf _httpClient) *http.Client {
+	return &http.Client{
+		Transport: conf.Transport,
+		Timeout:   time.Minute * 10,
+	}
+}

--- a/pkg/utils/http.go
+++ b/pkg/utils/http.go
@@ -31,6 +31,7 @@ type _httpTransport struct {
 func httpTransport(conf _httpTransport) *http.Transport {
 	return &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: conf.VerifySSL},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 }
 


### PR DESCRIPTION
Instantly declaring http.Transport in the request function may lead to coroutine leaks, as keepalive connections by default have no timeout and cannot be reused. In addition, it is necessary to Close Body and read the entire Body for each request.

https://github.com/naiba/nezha/blob/3059bf2d49effd78a1dfa1480d9035a487626b8d/model/notification.go#L120-L128

This PR addresses both issues and enables the http.Client to read proxy settings from environment variables in https://github.com/naiba/nezha/commit/61b845da7b9d28b780c40e7fbec56bb021924258, allowing the notification request to go through the proxy directly.
