### PR TITLE
fix: field name "VerifySSL" to "SkipVerifySSL" in Transport config

### DIFF
--- a/model/notification.go
+++ b/model/notification.go
@@ -110,15 +110,9 @@ func (n *Notification) setRequestHeader(req *http.Request) error {
 }
 
 func (ns *NotificationServerBundle) Send(message string) error {
-	var verifySSL bool
+	var client *http.Client
 	n := ns.Notification
 	if n.VerifySSL != nil && *n.VerifySSL {
-		verifySSL = true
-	}
-
-	var client *http.Client
-
-	if verifySSL {
 		client = utils.HttpClient
 	} else {
 		client = utils.HttpClientSkipTlsVerify

--- a/pkg/utils/http.go
+++ b/pkg/utils/http.go
@@ -14,23 +14,23 @@ var (
 func init() {
 	HttpClientSkipTlsVerify = httpClient(_httpClient{
 		Transport: httpTransport(_httpTransport{
-			VerifySSL: true,
+			SkipVerifySSL: true,
 		}),
 	})
 	HttpClient = httpClient(_httpClient{
 		Transport: httpTransport(_httpTransport{
-			VerifySSL: false,
+			SkipVerifySSL: false,
 		}),
 	})
 }
 
 type _httpTransport struct {
-	VerifySSL bool
+	SkipVerifySSL bool
 }
 
 func httpTransport(conf _httpTransport) *http.Transport {
 	return &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: conf.VerifySSL},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: conf.SkipVerifySSL},
 		Proxy:           http.ProxyFromEnvironment,
 	}
 }


### PR DESCRIPTION
我有点被绕糊涂了，是不是原来的逻辑反了，当 verifySSL 的值为 true 时 InsecureSkipVerify 应该为 false，但是在原来的代码中为 true

https://github.com/naiba/nezha/blob/3059bf2d49effd78a1dfa1480d9035a487626b8d/model/notification.go#L116-L122