### PR TITLE
installer: fix docker compose command determination

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -795,7 +795,7 @@ clean_all() {
 
 select_version() {
     DOCKER_COMPOSE_COMMAND=""
-    if command -v docker compose >/dev/null 2>&1; then
+    if docker compose version >/dev/null 2>&1; then
         DOCKER_COMPOSE_COMMAND="docker compose"
     elif command -v docker-compose >/dev/null 2>&1; then
         DOCKER_COMPOSE_COMMAND="docker-compose"

--- a/script/install_en.sh
+++ b/script/install_en.sh
@@ -793,7 +793,7 @@ clean_all() {
 
 select_version() {
     DOCKER_COMPOSE_COMMAND=""
-    if command -v docker compose >/dev/null 2>&1; then
+    if docker compose version >/dev/null 2>&1; then
         DOCKER_COMPOSE_COMMAND="docker compose"
     elif command -v docker-compose >/dev/null 2>&1; then
         DOCKER_COMPOSE_COMMAND="docker-compose"


### PR DESCRIPTION
original script can only check if 'docker' command exists, but not 'docker compose'.