### PR TITLE
Improve: use alpine as dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:edge
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,17 @@
-FROM ubuntu:focal-20221130
-
-ENV TZ="Asia/Shanghai"
+FROM alpine:latest
 
 ARG TARGETOS
 ARG TARGETARCH
 
-COPY ./script/entrypoint.sh /entrypoint.sh
+RUN apk update && \
+    apk upgrade --no-cache && \
+    apk add --no-cache tzdata && \
+    cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo 'Asia/Shanghai' >/etc/timezone && \
+    rm -rf /var/cache/apk/*
 
-RUN export DEBIAN_FRONTEND="noninteractive" && \
-    apt update && apt install -y ca-certificates tzdata && \
-    update-ca-certificates && \
-    ln -fs /usr/share/zoneinfo/$TZ /etc/localtime && \
-    dpkg-reconfigure tzdata && \
-    chmod +x /entrypoint.sh
+COPY ./script/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 WORKDIR /dashboard
 COPY dist/dashboard-${TARGETOS}-${TARGETARCH} ./app


### PR DESCRIPTION
By using the Alpine image, the image size has been reduced from 80MB to approximately 22MB. I have tested it on linux/amd64, and it runs smoothly. If Nezha does not have dependencies on the ubuntu-focal environment, using Alpine is a better choice.