### PR TITLE
feat: add network monitor hitory

### DIFF
--- a/cmd/dashboard/controller/common_page.go
+++ b/cmd/dashboard/controller/common_page.go
@@ -133,7 +133,7 @@ func (p *commonPage) service(c *gin.Context) {
 
 func (cp *commonPage) network(c *gin.Context) {
 	var (
-		monitorHistory       = &model.MonitorHistory{}
+		monitorHistory       *model.MonitorHistory
 		servers              []*model.Server
 		serverIdsWithMonitor []uint64
 		monitorInfos         = []byte("{}")

--- a/cmd/dashboard/controller/member_api.go
+++ b/cmd/dashboard/controller/member_api.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/copier"
+	"gorm.io/gorm"
 
 	"github.com/naiba/nezha/model"
 	"github.com/naiba/nezha/pkg/mygin"
@@ -185,7 +186,17 @@ func (ma *memberAPI) delete(c *gin.Context) {
 	var err error
 	switch c.Param("model") {
 	case "server":
-		err = singleton.DB.Unscoped().Delete(&model.Server{}, "id = ?", id).Error
+		err := singleton.DB.Transaction(func(tx *gorm.DB) error {
+			err = singleton.DB.Unscoped().Delete(&model.Server{}, "id = ?", id).Error
+			if err != nil {
+				return err
+			}
+			err = singleton.DB.Unscoped().Delete(&model.MonitorHistory{}, "server_id = ?", id).Error
+			if err != nil {
+				return err
+			}
+			return nil
+		})
 		if err == nil {
 			// 删除服务器
 			singleton.ServerLock.Lock()
@@ -426,6 +437,11 @@ func (ma *memberAPI) addOrEditMonitor(c *gin.Context) {
 			} else {
 				err = singleton.DB.Save(&m).Error
 			}
+		}
+		if m.Cover == 0 {
+			err = singleton.DB.Unscoped().Delete(&model.MonitorHistory{}, "monitor_id = ? and server_id in (?)", m.ID, m.SkipServersRaw[1:len(m.SkipServersRaw)-1]).Error
+		} else {
+			err = singleton.DB.Unscoped().Delete(&model.MonitorHistory{}, "monitor_id = ? and server_id not in (?)", m.ID, m.SkipServersRaw[1:len(m.SkipServersRaw)-1]).Error
 		}
 	}
 	if err == nil {

--- a/cmd/dashboard/controller/member_api.go
+++ b/cmd/dashboard/controller/member_api.go
@@ -439,9 +439,9 @@ func (ma *memberAPI) addOrEditMonitor(c *gin.Context) {
 			}
 		}
 		if m.Cover == 0 {
-			err = singleton.DB.Unscoped().Delete(&model.MonitorHistory{}, "monitor_id = ? and server_id in (?)", m.ID, m.SkipServersRaw[1:len(m.SkipServersRaw)-1]).Error
+			err = singleton.DB.Unscoped().Delete(&model.MonitorHistory{}, "monitor_id = ? and server_id in (?)", m.ID, strings.Split(m.SkipServersRaw[1:len(m.SkipServersRaw)-1], ",")).Error
 		} else {
-			err = singleton.DB.Unscoped().Delete(&model.MonitorHistory{}, "monitor_id = ? and server_id not in (?)", m.ID, m.SkipServersRaw[1:len(m.SkipServersRaw)-1]).Error
+			err = singleton.DB.Unscoped().Delete(&model.MonitorHistory{}, "monitor_id = ? and server_id not in (?)", m.ID, strings.Split(m.SkipServersRaw[1:len(m.SkipServersRaw)-1], ",")).Error
 		}
 	}
 	if err == nil {

--- a/cmd/dashboard/rpc/rpc.go
+++ b/cmd/dashboard/rpc/rpc.go
@@ -49,10 +49,20 @@ func DispatchTask(serviceSentinelDispatchBus <-chan model.Monitor) {
 				workedServerIndex++
 				continue
 			}
+			if task.Cover == model.MonitorCoverIgnoreAll && task.SkipServers[singleton.SortedServerList[workedServerIndex].ID] {
+				singleton.SortedServerList[workedServerIndex].TaskStream.Send(task.PB())
+				workedServerIndex++
+				continue
+			}
+			if task.Cover == model.MonitorCoverAll && !task.SkipServers[singleton.SortedServerList[workedServerIndex].ID] {
+				singleton.SortedServerList[workedServerIndex].TaskStream.Send(task.PB())
+				workedServerIndex++
+				continue
+			}
 			// 找到合适机器执行任务，跳出循环
-			singleton.SortedServerList[workedServerIndex].TaskStream.Send(task.PB())
-			workedServerIndex++
-			break
+			// singleton.SortedServerList[workedServerIndex].TaskStream.Send(task.PB())
+			// workedServerIndex++
+			// break
 		}
 		singleton.SortedServerLock.RUnlock()
 	}

--- a/model/config.go
+++ b/model/config.go
@@ -110,6 +110,8 @@ type Config struct {
 
 	v                              *viper.Viper
 	IgnoredIPNotificationServerIDs map[uint64]bool // [ServerID] -> bool(值为true代表当前ServerID在特定服务器列表内）
+	MaxTCPPingValue                int32
+	AvgPingCount                   int
 }
 
 // Read 读取配置文件并应用
@@ -143,6 +145,12 @@ func (c *Config) Read(path string) error {
 	}
 	if c.Location == "" {
 		c.Location = "Asia/Shanghai"
+	}
+	if c.MaxTCPPingValue == 0 {
+		c.MaxTCPPingValue = 300
+	}
+	if c.AvgPingCount == 0 {
+		c.AvgPingCount = 2
 	}
 
 	c.updateIgnoredIPNotificationID()

--- a/model/monitor.go
+++ b/model/monitor.go
@@ -20,7 +20,6 @@ const (
 	TaskTypeTerminal
 	TaskTypeUpgrade
 	TaskTypeKeepalive
-	TaskTypeTCPPingV2
 )
 
 type TerminalTask struct {

--- a/model/monitor.go
+++ b/model/monitor.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/naiba/nezha/pkg/utils"
-	pb "github.com/naiba/nezha/proto"
 	"github.com/robfig/cron/v3"
 	"gorm.io/gorm"
+
+	"github.com/naiba/nezha/pkg/utils"
+	pb "github.com/naiba/nezha/proto"
 )
 
 const (
@@ -19,6 +20,7 @@ const (
 	TaskTypeTerminal
 	TaskTypeUpgrade
 	TaskTypeKeepalive
+	TaskTypeTCPPingV2
 )
 
 type TerminalTask struct {

--- a/model/monitor_history.go
+++ b/model/monitor_history.go
@@ -1,9 +1,18 @@
 package model
 
+const (
+	Cycle = iota
+	Hour
+	Day
+	Week
+	Month
+)
+
 // MonitorHistory 历史监控记录
 type MonitorHistory struct {
 	Common
 	MonitorID uint64
+	ServerID  uint64
 	AvgDelay  float32 // 平均延迟，毫秒
 	Up        uint64  // 检查状态良好计数
 	Down      uint64  // 检查状态异常计数

--- a/resource/l10n/en-US.toml
+++ b/resource/l10n/en-US.toml
@@ -609,3 +609,6 @@ other = "Hide for Guest"
 
 [Menu]
 other = "Menu"
+
+[NetworkSpiter]
+other = "Network Monitor"

--- a/resource/l10n/es-ES.toml
+++ b/resource/l10n/es-ES.toml
@@ -609,3 +609,6 @@ other = "Ocultar para Invitados"
 
 [Menu]
 other = "Menú"
+
+[NetworkSpiter]
+other = "Supervisión De Redes"

--- a/resource/l10n/zh-CN.toml
+++ b/resource/l10n/zh-CN.toml
@@ -609,3 +609,6 @@ other = "对游客隐藏"
 
 [Menu]
 other = "菜单"
+
+[NetworkSpiter]
+other = "网络监控"

--- a/resource/l10n/zh-TW.toml
+++ b/resource/l10n/zh-TW.toml
@@ -609,3 +609,6 @@ other = "對遊客隱藏"
 
 [Menu]
 other = "菜單"
+
+[NetworkSpiter]
+other = "網絡監控"

--- a/resource/template/common/menu.html
+++ b/resource/template/common/menu.html
@@ -15,6 +15,7 @@
         {{else}}
         <a class='item{{if eq .MatchedPath "/"}} active{{end}}' href="/"><i class="home icon"></i>{{tr "Home"}}</a>
         <a class='item{{if eq .MatchedPath "/service"}} active{{end}}' href="/service"><i class="rss icon"></i>{{tr "Services"}}</a>
+        <a class='item{{if eq .MatchedPath "/network"}} active{{end}}' href="/network"><i class="server icon"></i>{{tr "NetworkSpiter"}}</a>
         {{end}}
         <div class="right menu">
             <div class="item">

--- a/resource/template/theme-daynight/home.html
+++ b/resource/template/theme-daynight/home.html
@@ -39,6 +39,7 @@
                 <ul>
                     <li><a href="/">{{tr "Home"}}</a></li>
                     <li><a href="/service">{{tr "Services"}}</a></li>
+                    <li><a href="/network">{{tr "NetworkSpiter"}}</a></li>
                     {{if .Admin}}
                     <li><a href="/server">{{tr "AdminPanel"}}</a></li>
                     {{else}}

--- a/resource/template/theme-daynight/network.html
+++ b/resource/template/theme-daynight/network.html
@@ -1,0 +1,268 @@
+{{define "theme-daynight/network"}}
+<!doctype html>
+<html lang="{{.Conf.Language}}">
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <title>{{.Title}}</title>
+    <link rel="shortcut icon" type="image/png" href="/static/logo.svg?v20210804" />
+
+    <link rel="stylesheet" href="/static/theme-daynight/css/main.css?v202108042286">
+    <link href="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-y/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <script src="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-y/jquery/3.6.0/jquery.min.js"></script>
+    <script src="https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/echarts/5.3.0-rc.1/echarts.min.js"></script>
+
+    {{if ts .CustomCode}}
+    {{.CustomCode|safe}}
+    {{end}}
+</head>
+
+<body data-theme="light" data-gridlist="grid">
+<header>
+    <section class="nav-bar clearfix">
+        <figure class="logo">
+            <a href="/">
+                <img src="/static/logo.svg?v20210804" alt='{{tr "NezhaMonitoring"}}' width="50" height="50">
+            </a>
+            <a href="/">{{.Conf.Site.Brand}}</a>
+        </figure>
+        <div class="icon-container">
+            <div class="row cf">
+                <div class="three col">
+                    <div class="hamburger" id="hamburger-icon"><span class="line"></span><span
+                            class="line"></span><span class="line"></span></div>
+                </div>
+            </div>
+        </div>
+        <nav class="nav-menu">
+            <ul>
+                <li><a href="/">{{tr "Home"}}</a></li>
+                <li><a href="/service">{{tr "Services"}}</a></li>
+                <li><a href="/network">{{tr "NetworkSpiter"}}</a></li>
+                {{if .Admin}}
+                <li><a href="/server">{{tr "AdminPanel"}}</a></li>
+                {{else}}
+                <li><a href="/login">{{tr "Login"}}</a></li>
+                {{end}}
+            </ul>
+        </nav>
+    </section>
+</header>
+
+<main>
+    <div id="network">
+        <div class="server-info-container" v-for='server in servers' :id="server.ID" style="font-size: .6em">
+            <div class="info-body" @click="redirectNetwork(server.ID)">
+                <ul class="server-info-body-container">
+                    <li>
+                        <h3>@#server.Name#@</h3>
+                    </li>
+                    <li><img :src="'/static/theme-daynight/img/flag/'+(server.Host&&server.Host.CountryCode?server.Host.CountryCode.toUpperCase():'CN')+'.png'"
+                             :title="server.Host.CountryCode.toUpperCase()" /></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="network-chart" style="height: 800px;overflow: hidden">
+        <div id="monitor-info-container" style="height: 520px;max-width: 1400px">
+        </div>
+    </div>
+    <div class="sidebar-container">
+        <ul>
+            <li><i class="fas fa-sun" title='{{tr "LightMode"}}'></i><span>{{tr "LightMode"}}</span></li>
+            <li><i class="fas fa-moon" title='{{tr "DarkMode"}}'></i><span>{{tr "DarkMode"}}</span></li>
+            <li><i class="fas fa-th" title='{{tr "GridLayout"}}'></i><span>{{tr "GridLayout"}}</span></li>
+            <li><i class="fas fa-list-ul" title='{{tr "ListLayout"}}'></i><span>{{tr "ListLayout"}}</span></li>
+        </ul>
+    </div>
+</main>
+
+<section class="dark-light-toggle">
+    <label class="switcher">
+        <input type="checkbox" name="theme" id="dark-light" />
+        <div>
+            <i class="fas fa-adjust"></i>
+        </div>
+    </label>
+</section>
+
+<!-- Back to top button -->
+<a id="back-to-top"></a>
+
+<footer>
+    <div class="footer-container">
+        <div><a href="https://github.com/naiba/nezha" target="_blank">Powered by {{tr "NezhaMonitoring"}} · {{.Version}}</a>
+            <p>&copy; <span id="copyright-date">
+                        <script>document.getElementById('copyright-date').appendChild(document.createTextNode(new Date().getFullYear()))</script>
+                    </span> · <a href="https://blog.jackiesung.com" target="_blank">Theme designed by Jackie Sung</a>
+            </p>
+        </div>
+    </div>
+</footer>
+
+<script src="/static/theme-daynight/js/main.js?v202102012266"></script>
+<script src="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-y/vue/2.6.14/vue.min.js"></script>
+<script src="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-y/limonte-sweetalert2/11.4.4/sweetalert2.all.min.js"></script>
+
+<script>
+        const monitorInfo =  JSON.parse('{{.MonitorInfos}}');
+        const initData = JSON.parse('{{.Servers}}').servers;
+        let MaxTCPPingValue = {{.MaxTCPPingValue}};
+	    if (MaxTCPPingValue == null) {
+	        MaxTCPPingValue = 300;
+	    }
+        // 基于准备好的dom，初始化echarts实例
+        var myChart = echarts.init(document.getElementById('monitor-info-container'));
+        // 使用刚指定的配置项和数据显示图表。
+        var statusCards = new Vue({
+            el: '#network',
+            delimiters: ['@#', '#@'],
+            data: {
+                servers: initData,
+                cache: [],
+                option: {
+                    tooltip: {
+                        trigger: 'axis',
+                        position: function (pt) {
+                            return [pt[0], '10%'];
+                        },
+                        formatter: function(params){
+                            let result = params[0].axisValueLabel + "<br />";
+                            params.forEach(function(item){
+                                result += item.marker + item.seriesName + ": " + item.value[1].toFixed(2) + " ms<br />";
+                             })
+                            return result;
+                        },
+                        confine: true,
+                        transitionDuration: 0
+                    },
+                    title: {
+                        left: 'center',
+                        text: "",
+                        textStyle: {}
+                    },
+                    legend: {
+                        top: '5%',
+                        data: [],
+                        textStyle: {
+                            fontSize: 14
+                        }
+                    },
+                    toolbox: {
+                        feature: {
+                            dataZoom: {
+                                yAxisIndex: 'none'
+                            },
+                            restore: {},
+                            saveAsImage: {}
+                        }
+                    },
+                    dataZoom: [
+                        {
+                            start: 94,
+                            end: 100
+                        }
+                    ],
+                    xAxis: {
+                        type: 'time',
+                        boundaryGap: false
+                    },
+                    yAxis: {
+                        type: 'value',
+                        boundaryGap: [0, '100%']
+                    },
+                    series: [],
+                }
+            },
+            mounted() {
+                this.DarkMode();
+                this.parseMonitorInfo(monitorInfo);
+            },
+            methods: {
+                DarkMode() {
+                    const hour = new Date(Date.now()).getHours()
+                    if (hour > 17 || hour < 4) {
+                        document.querySelector("input[name=theme]").checked = true;
+                        document.getElementsByTagName("BODY")[0].setAttribute('data-theme', 'dark');
+                        document.getElementById("monitor-info-container").style.backgroundColor = "#1E1E1E";
+                    }
+                },
+                redirectNetwork(id) {
+                    this.getMonitorHistory(id)
+                    .then(function(monitorInfo) {
+                          var vm = network.__vue__;
+                          vm.parseMonitorInfo(monitorInfo);
+                    })
+                    .catch(function(error){
+                        window.location.href = "/404";
+                    })
+                },
+                getMonitorHistory(id) {
+                      return $.ajax({
+                        url: "/api/v1/monitor/"+id,
+                        method: "GET"
+                      });
+                },
+                parseMonitorInfo(monitorInfo) {
+                    let tSeries = [];
+                    let tLegendData = [];
+                    for (let i = 0; i < monitorInfo.result.length; i++) {
+                        let loss = 0;
+                        let data = [];
+                        for (let j = 0; j < monitorInfo.result[i].created_at.length; j++) {
+                            avgDelay = monitorInfo.result[i].avg_delay[j];
+                            if (avgDelay > 0.9 * MaxTCPPingValue) {
+                                loss += 1
+                            }
+                            data.push([monitorInfo.result[i].created_at[j], avgDelay]);
+                        }
+                        lossRate = ((loss / monitorInfo.result[i].created_at.length) * 100).toFixed(1);
+			            legendName = monitorInfo.result[i].monitor_name +" "+ lossRate + "%";
+                        tLegendData.push(legendName);
+                        tSeries.push({
+                                name: legendName,
+                                type: 'line',
+                                smooth: true,
+                                symbol: 'none',
+                                data: data
+                        });
+                    }
+                    this.option.title.text = monitorInfo.result[0].server_name;
+                    this.option.series = tSeries;
+                    this.option.legend.data = tLegendData;
+                    const hour = new Date(Date.now()).getHours()
+                    if (hour > 17 || hour < 4) {
+                        this.option.legend.textStyle.color = "#F1F1F2";
+                        this.option.title.textStyle.color = "#ccc";
+                    }
+                    myChart.clear();
+                    myChart.setOption(this.option);
+                }
+            }
+        });
+    </script>
+</body>
+<style>
+#network {
+    display: grid;
+    /*grid-template-columns: repeat(5, 1fr);*/
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    grid-gap: 1em;
+    width: 100%;
+    width: calc(100vw - 6em);
+    max-width: 1400px;
+    margin: 1em auto;
+    align-content: start;
+}
+#monitor-info-container{
+    margin: 0em auto;
+    align-content: start;
+    background-color: #F1F1F2;
+}
+</style>
+
+</html>
+{{end}}
+

--- a/resource/template/theme-daynight/service.html
+++ b/resource/template/theme-daynight/service.html
@@ -43,6 +43,7 @@
               <ul>
                 <li><a href="/">{{tr "Home"}}</a></li>
                 <li><a href="/service">{{tr "Services"}}</a></li>
+                <li><a href="/network">{{tr "NetworkSpiter"}}</a></li>
                 {{if .Admin}}
                 <li><a href="/server">{{tr "AdminPanel"}}</a></li>
                 {{else}}

--- a/resource/template/theme-default/network.html
+++ b/resource/template/theme-default/network.html
@@ -1,0 +1,219 @@
+{{define "theme-default/network"}}
+{{template "common/header" .}}
+{{if ts .CustomCode}}
+{{.CustomCode|safe}}
+{{end}}
+{{template "common/menu" .}}
+<div class="nb-container" id="app">
+    <div class="ui container">
+        <div class="service-status">
+            <table class="ui celled table">
+                <button class="ui nezha-primary-btn button"
+                        v-for="server in servers"
+                        style="margin-top: 3px"
+                        @click="redirectNetwork(server.ID)">
+                    @#server.Name#@ &nbsp;<i :class="server.Host.CountryCode + ' flag'"></i>
+                </button>
+            </table>
+        </div>
+    </div>
+    <div class="ui container" style="max-width: 95vw">
+        <div ref="chartDom" style="border-radius: 28px; margin-top: 15px;height: 520px;max-width: 1400px;overflow: hidden"></div>
+    </div>
+</div>
+
+{{template "common/footer" .}}
+<script src="https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/echarts/5.3.0-rc.1/echarts.min.js"></script>
+
+<script>
+    const monitorInfo =  JSON.parse('{{.MonitorInfos}}');
+    const initData = JSON.parse('{{.Servers}}').servers;
+    let MaxTCPPingValue = {{.MaxTCPPingValue}};
+    if (MaxTCPPingValue == null) {
+        MaxTCPPingValue = 300;
+    }
+    new Vue({
+        el: '#app',
+        delimiters: ['@#', '#@'],
+        data: {
+            servers: initData,
+            option: {
+                tooltip: {
+                    trigger: 'axis',
+                    position: function (pt) {
+                        return [pt[0], '10%'];
+                    },
+                    formatter: function(params){
+                        let result = params[0].axisValueLabel + "<br />";
+                        params.forEach(function(item){
+                            result += item.marker + item.seriesName + ": " + item.value[1].toFixed(2) + " ms<br />";
+                         })
+                        return result;
+                    },
+                    confine: true,
+                    transitionDuration: 0
+                },
+                title: {
+                    left: 'center',
+                    text: "",
+                    textStyle: {}
+                },
+                legend: {
+                    top: '5%',
+                    data: [],
+                    textStyle: {
+                        fontSize: 14
+                    }
+                },
+                backgroundColor: 'rgba(255, 255, 255, 0.8)',
+                toolbox: {
+                    feature: {
+                        dataZoom: {
+                            yAxisIndex: 'none'
+                        },
+                        restore: {},
+                        saveAsImage: {}
+                    }
+                },
+                dataZoom: [
+                    {
+                        start: 94,
+                        end: 100
+                    }
+                ],
+                xAxis: {
+                    type: 'time',
+                    boundaryGap: false
+                },
+                yAxis: {
+                    type: 'value',
+                    boundaryGap: [0, '100%']
+                },
+                series: [],
+            },
+            chartOnOff: true,
+        },
+        mounted() {
+            this.renderChart();
+             this.parseMonitorInfo(monitorInfo);
+        },
+        methods: {
+            getFontLogoClass(str) {
+                if (["almalinux",
+                        "alpine",
+                        "aosc",
+                        "apple",
+                        "archlinux",
+                        "archlabs",
+                        "artix",
+                        "budgie",
+                        "centos",
+                        "coreos",
+                        "debian",
+                        "deepin",
+                        "devuan",
+                        "docker",
+                        "elementary",
+                        "fedora",
+                        "ferris",
+                        "flathub",
+                        "freebsd",
+                        "gentoo",
+                        "gnu-guix",
+                        "illumos",
+                        "kali-linux",
+                        "linuxmint",
+                        "mageia",
+                        "mandriva",
+                        "manjaro",
+                        "nixos",
+                        "openbsd",
+                        "opensuse",
+                        "pop-os",
+                        "raspberry-pi",
+                        "redhat",
+                        "rocky-linux",
+                        "sabayon",
+                        "slackware",
+                        "snappy",
+                        "solus",
+                        "tux",
+                        "ubuntu",
+                        "void",
+                        "zorin"].indexOf(str)
+                    > -1) {
+                    return str;
+                }
+                if (['openwrt', 'linux', "immortalwrt"].indexOf(str) > -1) {
+                    return 'tux';
+                }
+                if (str == 'amazon') {
+                    return 'redhat';
+                }
+                if (str == 'arch') {
+                    return 'archlinux';
+                }
+                return '';
+            },
+            redirectNetwork(id) {
+                    this.getMonitorHistory(id)
+                    .then(function(monitorInfo) {
+                          var vm = app.__vue__;
+                          vm.parseMonitorInfo(monitorInfo);
+                    })
+                    .catch(function(error){
+                        window.location.href = "/404";
+                    })
+                },
+            getMonitorHistory(id) {
+                  return $.ajax({
+                    url: "/api/v1/monitor/"+id,
+                    method: "GET"
+                  });
+            },
+            parseMonitorInfo(monitorInfo) {
+                let tSeries = [];
+                let tLegendData = [];
+                for (let i = 0; i < monitorInfo.result.length; i++) {
+                    let loss = 0;
+                    let data = [];
+                    for (let j = 0; j < monitorInfo.result[i].created_at.length; j++) {
+                        avgDelay = monitorInfo.result[i].avg_delay[j];
+                        if (avgDelay > 0.9 * MaxTCPPingValue) {
+                            loss += 1
+                        }
+                        data.push([monitorInfo.result[i].created_at[j], avgDelay]);
+                    }
+                    lossRate = ((loss / monitorInfo.result[i].created_at.length) * 100).toFixed(1);
+                    legendName = monitorInfo.result[i].monitor_name +" "+ lossRate + "%";
+                    tLegendData.push(legendName);
+                    tSeries.push({
+                            name: legendName,
+                            type: 'line',
+                            smooth: true,
+                            symbol: 'none',
+                            data: data
+                    });
+                }
+                this.option.title.text = monitorInfo.result[0].server_name;
+                this.option.series = tSeries;
+                this.option.legend.data = tLegendData;
+                this.myChart.clear();
+                this.myChart.setOption(this.option);
+            },
+            isWindowsPlatform(str) {
+                return str.includes('Windows')
+            },
+            renderChart() {
+              this.myChart = echarts.init(this.$refs.chartDom);
+              this.myChart.setOption(this.option);
+            },
+        },
+        beforeDestroy() {
+            this.myChart.dispose();
+            this.myChart = null;
+        },
+    });
+</script>
+
+{{end}}

--- a/resource/template/theme-server-status/content-nav.html
+++ b/resource/template/theme-server-status/content-nav.html
@@ -18,6 +18,7 @@
                 <ul class="nav navbar-nav">
                     <li><a href="/">{{tr "Home" }}</a></li>
                     <li><a href="/service">{{tr "Services" }}</a></li>
+                    <li><a href="/network">{{tr "NetworkSpiter" }}</a></li>
                 </ul>
                 <ul class="nav navbar-nav navbar-right">
                     <li class="dropdown">
@@ -45,3 +46,4 @@
     </div>
 </div>
 {{end}}
+

--- a/resource/template/theme-server-status/header.html
+++ b/resource/template/theme-server-status/header.html
@@ -28,6 +28,7 @@
     <script src="/static/theme-server-status/js/bootstrap.min.js"></script>
     <script src="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-y/vue/2.6.14/vue.min.js"></script>
     <script src="/static/theme-server-status/js/mixin.js"></script>
+    <script src="https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/echarts/5.3.0-rc.1/echarts.min.js"></script>
 </head>
 <body>
 {{end}}

--- a/resource/template/theme-server-status/network.html
+++ b/resource/template/theme-server-status/network.html
@@ -1,0 +1,217 @@
+{{define "theme-server-status/network"}}
+{{template "theme-server-status/header" .}}
+<div id="app">
+    {{template "theme-server-status/content-nav" .}}
+    <div class="container table-responsive content" style="max-width: 95vw">
+        <table class="table table-striped table-condensed table-hover">
+            <button class="ui nezha-primary-btn button"
+                    v-for="server in servers"
+                    style="margin-top: 3px"
+                    @click="redirectNetwork(server.ID)">
+                @#server.Name#@&nbsp;&nbsp;<i :class="'fi fi-' + server.Host.CountryCode"></i><span class="node-cell-location-text text-uppercase">&nbsp;&nbsp;@#server.Host.CountryCode#@</span>
+            </button>
+        </table>
+    </div>
+    <div class="container table-responsive content" style="max-width: 95vw">
+        <div ref="chartDom" style="border-radius: 28px; margin-top: 15px;height: 520px;max-width: 1400px;overflow: hidden"></div>
+    </div>
+    {{template "theme-server-status/content-footer" .}}
+</div>
+
+<script>
+    const monitorInfo =  JSON.parse('{{.MonitorInfos}}');
+    const initData = JSON.parse('{{.Servers}}').servers;
+    let MaxTCPPingValue = {{.MaxTCPPingValue}};
+    if (MaxTCPPingValue == null) {
+        MaxTCPPingValue = 300;
+    }
+    new Vue({
+        el: '#app',
+        delimiters: ['@#', '#@'],
+        data: {
+            servers: initData,
+            option: {
+                tooltip: {
+                    trigger: 'axis',
+                    position: function (pt) {
+                        return [pt[0], '10%'];
+                    },
+                    formatter: function(params){
+                        let result = params[0].axisValueLabel + "<br />";
+                        params.forEach(function(item){
+                            result += item.marker + item.seriesName + ": " + item.value[1].toFixed(2) + " ms<br />";
+                         })
+                        return result;
+                    },
+                    confine: true,
+                    transitionDuration: 0
+                },
+                title: {
+                    left: 'center',
+                    text: "",
+                    textStyle: {}
+                },
+                legend: {
+                    top: '5%',
+                    data: [],
+                    textStyle: {
+                        fontSize: 14
+                    }
+                },
+                backgroundColor: 'rgba(255, 255, 255, 0.8)',
+                toolbox: {
+                    feature: {
+                        dataZoom: {
+                            yAxisIndex: 'none'
+                        },
+                        restore: {},
+                        saveAsImage: {}
+                    }
+                },
+                dataZoom: [
+                    {
+                        start: 94,
+                        end: 100
+                    }
+                ],
+                xAxis: {
+                    type: 'time',
+                    boundaryGap: false
+                },
+                yAxis: {
+                    type: 'value',
+                    boundaryGap: [0, '100%']
+                },
+                series: [],
+            },
+            chartOnOff: true,
+        },
+        mixins: [mixinsVue],
+        created() {
+            this.initTheme();
+        },
+        mounted() {
+            this.renderChart();
+             this.parseMonitorInfo(monitorInfo);
+        },
+        methods: {
+            getFontLogoClass(str) {
+                if (["almalinux",
+                        "alpine",
+                        "aosc",
+                        "apple",
+                        "archlinux",
+                        "archlabs",
+                        "artix",
+                        "budgie",
+                        "centos",
+                        "coreos",
+                        "debian",
+                        "deepin",
+                        "devuan",
+                        "docker",
+                        "elementary",
+                        "fedora",
+                        "ferris",
+                        "flathub",
+                        "freebsd",
+                        "gentoo",
+                        "gnu-guix",
+                        "illumos",
+                        "kali-linux",
+                        "linuxmint",
+                        "mageia",
+                        "mandriva",
+                        "manjaro",
+                        "nixos",
+                        "openbsd",
+                        "opensuse",
+                        "pop-os",
+                        "raspberry-pi",
+                        "redhat",
+                        "rocky-linux",
+                        "sabayon",
+                        "slackware",
+                        "snappy",
+                        "solus",
+                        "tux",
+                        "ubuntu",
+                        "void",
+                        "zorin"].indexOf(str)
+                    > -1) {
+                    return str;
+                }
+                if (['openwrt', 'linux', "immortalwrt"].indexOf(str) > -1) {
+                    return 'tux';
+                }
+                if (str == 'amazon') {
+                    return 'redhat';
+                }
+                if (str == 'arch') {
+                    return 'archlinux';
+                }
+                return '';
+            },
+            redirectNetwork(id) {
+                    this.getMonitorHistory(id)
+                    .then(function(monitorInfo) {
+                          var vm = app.__vue__;
+                          vm.parseMonitorInfo(monitorInfo);
+                    })
+                    .catch(function(error){
+                        window.location.href = "/404";
+                    })
+                },
+            getMonitorHistory(id) {
+                  return $.ajax({
+                    url: "/api/v1/monitor/"+id,
+                    method: "GET"
+                  });
+            },
+            parseMonitorInfo(monitorInfo) {
+                let tSeries = [];
+                let tLegendData = [];
+                for (let i = 0; i < monitorInfo.result.length; i++) {
+                    let loss = 0;
+                    let data = [];
+                    for (let j = 0; j < monitorInfo.result[i].created_at.length; j++) {
+                        avgDelay = monitorInfo.result[i].avg_delay[j];
+                        if (avgDelay > 0.9 * MaxTCPPingValue) {
+                            loss += 1
+                        }
+                        data.push([monitorInfo.result[i].created_at[j], avgDelay]);
+                    }
+                    lossRate = ((loss / monitorInfo.result[i].created_at.length) * 100).toFixed(1);
+                    legendName = monitorInfo.result[i].monitor_name +" "+ lossRate + "%";
+                    tLegendData.push(legendName);
+                    tSeries.push({
+                            name: legendName,
+                            type: 'line',
+                            smooth: true,
+                            symbol: 'none',
+                            data: data
+                    });
+                }
+                this.option.title.text = monitorInfo.result[0].server_name;
+                this.option.series = tSeries;
+                this.option.legend.data = tLegendData;
+                this.myChart.clear();
+                this.myChart.setOption(this.option);
+            },
+            isWindowsPlatform(str) {
+                return str.includes('Windows')
+            },
+            renderChart() {
+              this.myChart = echarts.init(this.$refs.chartDom);
+              this.myChart.setOption(this.option);
+            },
+        },
+        beforeDestroy() {
+            this.myChart.dispose();
+            this.myChart = null;
+        },
+    });
+</script>
+{{template "theme-server-status/footer" .}}
+{{end}}
+

--- a/service/singleton/singleton.go
+++ b/service/singleton/singleton.go
@@ -99,6 +99,7 @@ func RecordTransferHourlyUsage() {
 func CleanMonitorHistory() {
 	// 清理已被删除的服务器的监控记录与流量记录
 	DB.Unscoped().Delete(&model.MonitorHistory{}, "created_at < ? OR monitor_id NOT IN (SELECT `id` FROM monitors)", time.Now().AddDate(0, 0, -30))
+	DB.Unscoped().Delete(&model.MonitorHistory{}, "(created_at < ? AND server_id != 0) OR monitor_id NOT IN (SELECT `id` FROM monitors)", time.Now().AddDate(0, 0, -3))
 	DB.Unscoped().Delete(&model.Transfer{}, "server_id NOT IN (SELECT `id` FROM servers)")
 	// 计算可清理流量记录的时长
 	var allServerKeep time.Time

--- a/service/singleton/singleton.go
+++ b/service/singleton/singleton.go
@@ -99,7 +99,10 @@ func RecordTransferHourlyUsage() {
 func CleanMonitorHistory() {
 	// 清理已被删除的服务器的监控记录与流量记录
 	DB.Unscoped().Delete(&model.MonitorHistory{}, "created_at < ? OR monitor_id NOT IN (SELECT `id` FROM monitors)", time.Now().AddDate(0, 0, -30))
-	DB.Unscoped().Delete(&model.MonitorHistory{}, "(created_at < ? AND server_id != 0) OR monitor_id NOT IN (SELECT `id` FROM monitors)", time.Now().AddDate(0, 0, -3))
+	// 由于网络监控记录的数据较多，并且前端仅使用了 1 天的数据
+	// 考虑到 sqlite 数据量问题，仅保留一天数据，
+	// server_id = 0 的数据会用于/service页面的可用性展示
+	DB.Unscoped().Delete(&model.MonitorHistory{}, "(created_at < ? AND server_id != 0) OR monitor_id NOT IN (SELECT `id` FROM monitors)", time.Now().AddDate(0, 0, -1))
 	DB.Unscoped().Delete(&model.Transfer{}, "server_id NOT IN (SELECT `id` FROM servers)")
 	// 计算可清理流量记录的时长
 	var allServerKeep time.Time


### PR DESCRIPTION
大佬，这个 mr 是面板新增 ping 历史趋势图的改动：
1. 新增网络监控页面
2. 新增接口指定 server_id 查询监控历史
3. 下发 Task 逻辑上做了变更，覆盖所有时，指定的 server 为不下发，其余都下发
4. proto 部分 task 新增 server_id 字段用于识别监控记录是哪个server ping 的

麻烦帮忙看看这样设计 和 编码是否合理 Orz

具体效果大概这样的[https://tz.181000.xyz/network](https://tz.181000.xyz/network)