### PR TITLE
fix: revert service html and block service in backend

### DIFF
--- a/cmd/dashboard/controller/common_page.go
+++ b/cmd/dashboard/controller/common_page.go
@@ -118,6 +118,11 @@ func (p *commonPage) service(c *gin.Context) {
 		var statsStore map[uint64]model.CycleTransferStats
 		copier.Copy(&stats, singleton.ServiceSentinelShared.LoadStats())
 		copier.Copy(&statsStore, singleton.AlertsCycleTransferStatsStore)
+		for k, service := range stats {
+			if !service.Monitor.EnableShowInService {
+				delete(stats, k)
+			}
+		}
 		return []interface {
 		}{
 			stats, statsStore,

--- a/resource/template/theme-daynight/service.html
+++ b/resource/template/theme-daynight/service.html
@@ -61,7 +61,6 @@
         </section>
         <section class="monitor-container">
           {{range $service := .Services}}
-          {{if $service.Monitor.EnableShowInService}}
           <section class="monitor-info-container">
             <div class="monitor-state">
               <span class="monitor-state-dot {{className (divU64 $service.CurrentUp (addU64 $service.CurrentUp $service.CurrentDown))}}"></span>
@@ -83,7 +82,6 @@
             </div>
           </section>
             {{end}}
-          {{end}}
         </section>
         {{if .CycleTransferStats}}
     <h2 class="mdui-m-t-5 mdui-text-center">{{tr "CycleTransferStats"}}</h2>

--- a/resource/template/theme-default/service.html
+++ b/resource/template/theme-default/service.html
@@ -18,7 +18,6 @@
                 </thead>
                 <tbody>
                     {{range $service := .Services}}
-                    {{if $service.Monitor.EnableShowInService}}
                     <tr>
                         <td class="ui center aligned">{{$service.Monitor.Name}}</td>
                         <td class="ui center aligned">
@@ -34,7 +33,7 @@
                                 class="delay-today {{className (divU64 $service.CurrentUp (addU64 $service.CurrentUp $service.CurrentDown))}}"></i>
                             {{statusName (divU64 $service.CurrentUp (addU64 $service.CurrentUp $service.CurrentDown))}}
                         </td>
-                    </tr> {{end}} {{end}}
+                    </tr> {{end}}
                 </tbody>
             </table>
 

--- a/resource/template/theme-server-status/service.html
+++ b/resource/template/theme-server-status/service.html
@@ -15,7 +15,7 @@
             </thead>
             <tbody id="servers">
             <template v-for="service in services">
-                <tr v-if="service.enableShow === 'true'">
+                <tr>
                     <td class="node-cell center">
                         <div class="delay-today">
                             <i class="delay-today" :class="service.health.className"></i>
@@ -137,7 +137,6 @@
                     delay: '{{$service.Delay}}'.replaceAll("[","").replaceAll("]","").split(" "),
                     up: '{{$service.Up}}'.replaceAll("[","").replaceAll("]","").split(" "),
                     down: '{{$service.Down}}'.replaceAll("[","").replaceAll("]","").split(" "),
-                    enableShow: '{{$service.Monitor.EnableShowInService}}',
                 })
                 {{end}}
                 // @formatter:on


### PR DESCRIPTION
主要改动点：
1. revert 主题 `service.html` 中的变更
2. 在后端 `/service` 中提前判断是否需要展示，返回给前端的数据，全部都拿来展示，避免每个主题都需要适配