### PR TITLE
improve: replace JsDelivr with SUStech and domains convergence

### DIFF
--- a/resource/template/theme-daynight/network.html
+++ b/resource/template/theme-daynight/network.html
@@ -8,11 +8,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <title>{{.Title}}</title>
     <link rel="shortcut icon" type="image/png" href="/static/logo.svg?v20210804" />
-
     <link rel="stylesheet" href="/static/theme-daynight/css/main.css?v202108042286">
     <link href="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-y/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <script src="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-y/jquery/3.6.0/jquery.min.js"></script>
-    <script src="https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/echarts/5.3.0-rc.1/echarts.min.js"></script>
+    <script src="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-M/echarts/5.3.0-rc.1/echarts.min.js"></script>
 
     {{if ts .CustomCode}}
     {{.CustomCode|safe}}

--- a/resource/template/theme-default/network.html
+++ b/resource/template/theme-default/network.html
@@ -23,7 +23,7 @@
 </div>
 
 {{template "common/footer" .}}
-<script src="https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/echarts/5.3.0-rc.1/echarts.min.js"></script>
+<script src="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-M/echarts/5.3.0-rc.1/echarts.min.js"></script>
 
 <script>
     const monitorInfo =  JSON.parse('{{.MonitorInfos}}');

--- a/resource/template/theme-server-status/header.html
+++ b/resource/template/theme-server-status/header.html
@@ -6,15 +6,17 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel=preconnect href=https://lf6-cdn-tos.bytecdntp.com>
+    <link rel=preconnect href=https://mirrors.sustech.edu.cn>
     <link rel="stylesheet" href="/static/theme-server-status/css/bootstrap.min.css">
     <link rel="stylesheet" href="/static/theme-server-status/css/bootstrap-theme.min.css">
     <link rel="stylesheet" href="/static/theme-server-status/css/main.css?v20231207">
     <link rel="stylesheet" href="/static/theme-server-status/css/dark.css">
     <link rel="stylesheet" href="/static/theme-server-status/css/light.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.2/font/bootstrap-icons.min.css">
+    <link rel="stylesheet" href="https://mirrors.sustech.edu.cn/cdnjs/ajax/libs/bootstrap-icons/1.11.2/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-y/font-logos/0.17/font-logos.min.css">
     <link rel="stylesheet" href="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-y/semantic-ui/2.4.1/semantic.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/lipis/flag-icons@7.0.0/css/flag-icons.min.css">
+    <link rel="stylesheet" href="https://mirrors.sustech.edu.cn/cdnjs/ajax/libs/flag-icons/7.0.0/css/flag-icons.min.css">
     <link rel="shortcut icon" type="image/png" href="/static/logo.svg?v20210804" />
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -28,7 +30,7 @@
     <script src="/static/theme-server-status/js/bootstrap.min.js"></script>
     <script src="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-y/vue/2.6.14/vue.min.js"></script>
     <script src="/static/theme-server-status/js/mixin.js"></script>
-    <script src="https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/echarts/5.3.0-rc.1/echarts.min.js"></script>
+    <script src="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-M/echarts/5.3.0-rc.1/echarts.min.js"></script>
 </head>
 <body>
 {{end}}


### PR DESCRIPTION
-  JsDelivr has poor performace in China, so this replacement will greatly improve loading speed for users in China.
- Unify resources loaded from ByteDance public libraries to `lf6-cdn-tos.bytecdntp.com` to converge DNS and HTTP requests.
- SUStech mirror has only one server located in China, so overseas users may feels slow when loading. Therefore Zstatic may be another choice since its' both Mainland China and overseas CDN servers, like:

`https://s4.zstatic.net/ajax/libs/bootstrap-icons/1.11.2/font/bootstrap-icons.min.css`
`https://s4.zstatic.net/ajax/libs/flag-icons/7.0.0/css/flag-icons.min.css`

![Screenshot 2024-02-16 161220](https://github.com/naiba/nezha/assets/121652515/1c354333-15e8-4968-baea-8daceb8e5165)
![Screenshot 2024-02-16 161254](https://github.com/naiba/nezha/assets/121652515/998ad9ed-9971-4197-a9c3-cf8b213d560f)





