### PR TITLE
feat: add index on monitor history

### DIFF
--- a/model/monitor_history.go
+++ b/model/monitor_history.go
@@ -1,20 +1,22 @@
 package model
 
-const (
-	Cycle = iota
-	Hour
-	Day
-	Week
-	Month
+import (
+	"time"
+
+	"gorm.io/gorm"
 )
 
 // MonitorHistory 历史监控记录
 type MonitorHistory struct {
-	Common
-	MonitorID uint64
-	ServerID  uint64
-	AvgDelay  float32 // 平均延迟，毫秒
-	Up        uint64  // 检查状态良好计数
-	Down      uint64  // 检查状态异常计数
+	ID        uint64         `gorm:"primaryKey"`
+	CreatedAt time.Time      `gorm:"index;<-:create;index:idx_server_id_created_at_monitor_id_avg_delay"`
+	UpdatedAt time.Time      `gorm:"autoUpdateTime"`
+	DeletedAt gorm.DeletedAt `gorm:"index"`
+	MonitorID uint64         `gorm:"index:idx_server_id_created_at_monitor_id_avg_delay"`
+	ServerID  uint64         `gorm:"index:idx_server_id_created_at_monitor_id_avg_delay"`
+	AvgDelay  float32        `gorm:"index:idx_server_id_created_at_monitor_id_avg_delay"` // 平均延迟，毫秒
+	Up        uint64         // 检查状态良好计数
+	Down      uint64         // 检查状态异常计数
 	Data      string
 }
+


### PR DESCRIPTION
改动：
1. 删除无用代码
2. 在下面这个查询中会使用到`server_id、monitor_id、created_at`， 实际select会多一个`avg_delay`字段，因此考虑直接添加覆盖索引避免回表查询
3. 因为 created_at 字段在 common 里面不太好加覆盖索引，因此把里面的字段直接复制了出来添加索引（这个我这没找到太好的方法）
```
DB.Model(&model.MonitorHistory{}).Select("monitor_id, created_at, server_id, avg_delay").
		Where(query).Where("created_at >= ?", time.Now().Add(-24*time.Hour)).Order("monitor_id, created_at").
		Scan(&monitorHistories).Error
```