### PR TITLE
优化安装逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <br>
   <small><i>LOGO designed by <a href="https://xio.ng" target="_blank">熊大</a> .</i></small>
   <br><br>
-<img alt="GitHub release (with filter)" src="https://img.shields.io/github/v/release/naiba/nezha?color=brightgreen&style=for-the-badge&logo=github&label=Dashboard">&nbsp;<img src="https://img.shields.io/github/v/release/nezhahq/agent?color=brightgreen&label=Agent&style=for-the-badge&logo=github">&nbsp;<img src="https://img.shields.io/github/actions/workflow/status/nezhahq/agent/agent.yml?label=Agent%20CI&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/badge/Installer-v0.15.7-brightgreen?style=for-the-badge&logo=linux">
+<img alt="GitHub release (with filter)" src="https://img.shields.io/github/v/release/naiba/nezha?color=brightgreen&style=for-the-badge&logo=github&label=Dashboard">&nbsp;<img src="https://img.shields.io/github/v/release/nezhahq/agent?color=brightgreen&label=Agent&style=for-the-badge&logo=github">&nbsp;<img src="https://img.shields.io/github/actions/workflow/status/nezhahq/agent/agent.yml?label=Agent%20CI&logo=github&style=for-the-badge">&nbsp;<img src="https://img.shields.io/badge/Installer-v0.15.8-brightgreen?style=for-the-badge&logo=linux">
   <br>
   <br>
   <p>:trollface: <b>Nezha Monitoring: Self-hostable, lightweight, servers and websites monitoring and O&M tool.</b></p>

--- a/script/install.sh
+++ b/script/install.sh
@@ -269,7 +269,8 @@ install_dashboard_standalone() {
 
 selinux() {
     #判断当前的状态
-    if [ "$os_alpine" != 1 ]; then
+    command -v getenforce >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
         getenforce | grep '[Ee]nfor'
         if [ $? -eq 0 ]; then
             echo -e "SELinux是开启状态，正在关闭！"

--- a/script/install.sh
+++ b/script/install.sh
@@ -14,7 +14,7 @@ NZ_AGENT_SERVICE="/etc/systemd/system/nezha-agent.service"
 NZ_AGENT_SERVICERC="/etc/init.d/nezha-agent"
 NZ_DASHBOARD_SERVICE="/etc/systemd/system/nezha-dashboard.service"
 NZ_DASHBOARD_SERVICERC="/etc/init.d/nezha-dashboard"
-NZ_VERSION="v0.15.7"
+NZ_VERSION="v0.15.8"
 
 red='\033[0;31m'
 green='\033[0;32m'

--- a/script/install_en.sh
+++ b/script/install_en.sh
@@ -14,7 +14,7 @@ NZ_AGENT_SERVICE="/etc/systemd/system/nezha-agent.service"
 NZ_AGENT_SERVICERC="/etc/init.d/nezha-agent"
 NZ_DASHBOARD_SERVICE="/etc/systemd/system/nezha-dashboard.service"
 NZ_DASHBOARD_SERVICERC="/etc/init.d/nezha-dashboard"
-NZ_VERSION="v0.15.7"
+NZ_VERSION="v0.15.8"
 
 red='\033[0;31m'
 green='\033[0;32m'

--- a/script/install_en.sh
+++ b/script/install_en.sh
@@ -266,7 +266,8 @@ install_dashboard_standalone() {
 
 selinux() {
     #Check SELinux
-    if [ "$os_alpine" != 1 ]; then
+    command -v getenforce >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
         getenforce | grep '[Ee]nfor'
         if [ $? -eq 0 ]; then
             echo -e "SELinux running，closing now！"


### PR DESCRIPTION
将逻辑修改为如果没有 `getenforce` 则不执行相关逻辑，解决在不安装 selinux 的 archlinux 系统上执行`getenforce` 出现 `command not found` 的问题.