### PR TITLE
网络监控页面相关优化

### DIFF
--- a/resource/template/theme-daynight/network.html
+++ b/resource/template/theme-daynight/network.html
@@ -111,7 +111,7 @@
         const initData = JSON.parse('{{.Servers}}').servers;
         let MaxTCPPingValue = {{.Conf.MaxTCPPingValue}};
 	    if (MaxTCPPingValue == null) {
-	        MaxTCPPingValue = 300;
+	        MaxTCPPingValue = 1000;
 	    }
         // 基于准备好的dom，初始化echarts实例
         var myChart = echarts.init(document.getElementById('monitor-info-container'));
@@ -179,6 +179,10 @@
             mounted() {
                 this.DarkMode();
                 this.parseMonitorInfo(monitorInfo);
+		window.addEventListener('resize', this.resizeHandle);
+            },
+	    destroyed () {
+                window.removeEventListener('resize', this.resizeHandle)
             },
             methods: {
                 DarkMode() {
@@ -239,7 +243,10 @@
                     }
                     myChart.clear();
                     myChart.setOption(this.option);
-                }
+                },
+	        resizeHandle () {
+                    this.myChart.resize();
+                },
             }
         });
     </script>

--- a/resource/template/theme-default/network.html
+++ b/resource/template/theme-default/network.html
@@ -17,7 +17,7 @@
             </table>
         </div>
     </div>
-    <div class="ui container" style="max-width: 95vw">
+    <div class="ui container">
         <div ref="chartDom" style="border-radius: 28px; margin-top: 15px;height: 520px;max-width: 1400px;overflow: hidden"></div>
     </div>
 </div>
@@ -67,6 +67,10 @@
                         fontSize: 14
                     }
                 },
+                grid: {
+                    left: '8%',
+                    right: '8%',
+                },
                 backgroundColor: 'rgba(255, 255, 255, 0.8)',
                 toolbox: {
                     feature: {
@@ -98,7 +102,11 @@
         mixins: [mixinsVue],
         mounted() {
             this.renderChart();
-             this.parseMonitorInfo(monitorInfo);
+            this.parseMonitorInfo(monitorInfo);
+            window.addEventListener('resize', this.resizeHandle);
+        },
+        destroyed () {
+            window.removeEventListener('resize', this.resizeHandle)
         },
         methods: {
             getFontLogoClass(str) {
@@ -218,6 +226,9 @@
             renderChart() {
               this.myChart = echarts.init(this.$refs.chartDom);
               this.myChart.setOption(this.option);
+            },
+            resizeHandle () {
+              this.myChart.resize();
             },
         },
         beforeDestroy() {

--- a/resource/template/theme-mdui/network.html
+++ b/resource/template/theme-mdui/network.html
@@ -38,7 +38,7 @@
             </table>
         </div>
     </div>
-    <div class="ui container" style="max-width: 95vw">
+    <div class="ui container">
         <div ref="chartDom" style="border-radius: 28px; margin-top: 15px;height: 520px;max-width: 1400px;overflow: hidden"></div>
     </div>
 </div>
@@ -91,6 +91,10 @@
                         fontSize: 14
                     }
                 },
+		grid: {
+                    left: '8%',
+                    right: '8%'
+                },
                 backgroundColor: 'rgba(255, 255, 255, 0.8)',
                 toolbox: {
                     feature: {
@@ -121,7 +125,11 @@
         },
         mounted() {
             this.renderChart();
-             this.parseMonitorInfo(monitorInfo);
+            this.parseMonitorInfo(monitorInfo);
+	    window.addEventListener('resize', this.resizeHandle);
+        },
+	resizeHandle () {
+              this.myChart.resize();
         },
         methods: {
             getFontLogoClass(str) {
@@ -241,6 +249,9 @@
             renderChart() {
               this.myChart = echarts.init(this.$refs.chartDom);
               this.myChart.setOption(this.option);
+            },
+	    resizeHandle () {
+              this.myChart.resize();
             },
         },
         beforeDestroy() {


### PR DESCRIPTION
更改：
 1. theme-daynight 的默认最大 TCPing 从 300 更为 1000，与 theme-default 统一；
 2. 删去各模板设置的 echarts 布局最大宽度（95vw），改为使用 grid 设置 echarts 左右空白各 8% 实现居中。

增加：
 1. 增加 echarts 宽度自适应功能，当屏幕宽度改变（例如：横屏切换为竖屏）时自动重新设置 echarts 宽度。