### PR TITLE
ddns: Add ability to update IPv4 or IPv6 only

### DIFF
--- a/cmd/dashboard/controller/member_api.go
+++ b/cmd/dashboard/controller/member_api.go
@@ -301,6 +301,8 @@ type serverForm struct {
 	Note         string
 	HideForGuest string
 	EnableDDNS   string
+	EnableIPv4   string
+	EnableIpv6   string
 	DDNSDomain   string
 }
 
@@ -318,6 +320,8 @@ func (ma *memberAPI) addOrEditServer(c *gin.Context) {
 		s.Note = sf.Note
 		s.HideForGuest = sf.HideForGuest == "on"
 		s.EnableDDNS = sf.EnableDDNS == "on"
+		s.EnableIPv4 = sf.EnableIPv4 == "on"
+		s.EnableIpv6 = sf.EnableIpv6 == "on"
 		s.DDNSDomain = sf.DDNSDomain
 		if s.ID == 0 {
 			s.Secret, err = utils.GenerateRandomString(18)

--- a/model/server.go
+++ b/model/server.go
@@ -18,6 +18,8 @@ type Server struct {
 	DisplayIndex int    // 展示排序，越大越靠前
 	HideForGuest bool   // 对游客隐藏
 	EnableDDNS   bool   // 是否启用DDNS 未在配置文件中启用DDNS 或 DDNS检查时间为0时此项无效
+	EnableIPv4   bool   // 是否启用DDNS IPv4
+	EnableIpv6   bool   // 是否启用DDNS IPv6
 	DDNSDomain   string // DDNS中的前缀 如基础域名为abc.oracle DDNSName为mjj 就会把mjj.abc.oracle解析服务器IP 为空则停用
 
 	Host       *Host      `gorm:"-"`
@@ -54,5 +56,5 @@ func (s Server) Marshal() template.JS {
 	note, _ := utils.Json.Marshal(s.Note)
 	secret, _ := utils.Json.Marshal(s.Secret)
 	ddnsDomain, _ := utils.Json.Marshal(s.DDNSDomain)
-	return template.JS(fmt.Sprintf(`{"ID":%d,"Name":%s,"Secret":%s,"DisplayIndex":%d,"Tag":%s,"Note":%s,"HideForGuest": %s,"EnableDDNS": %s,"DDNSDomain": %s}`, s.ID, name, secret, s.DisplayIndex, tag, note, boolToString(s.HideForGuest), boolToString(s.EnableDDNS), ddnsDomain)) // #nosec
+	return template.JS(fmt.Sprintf(`{"ID":%d,"Name":%s,"Secret":%s,"DisplayIndex":%d,"Tag":%s,"Note":%s,"HideForGuest": %s,"EnableDDNS": %s,"EnableIPv4": %s,"EnableIpv6": %s,"DDNSDomain": %s}`, s.ID, name, secret, s.DisplayIndex, tag, note, boolToString(s.HideForGuest), boolToString(s.EnableDDNS), boolToString(s.EnableIPv4), boolToString(s.EnableIpv6), ddnsDomain)) // #nosec
 }

--- a/resource/l10n/en-US.toml
+++ b/resource/l10n/en-US.toml
@@ -619,6 +619,12 @@ other = "Enable Show in Service"
 [EnableDDNS]
 other = "Enable DDNS"
 
+[EnableIPv4]
+other = "Enable DDNS IPv4"
+
+[EnableIpv6]
+other = "Enable DDNS IPv6"
+
 [DDNSDomain]
 other = "DDNS Domain"
 

--- a/resource/l10n/es-ES.toml
+++ b/resource/l10n/es-ES.toml
@@ -619,6 +619,12 @@ other = "Mostrar en servicio"
 [EnableDDNS]
 other = "Habilitar DDNS"
 
+[EnableIPv4]
+other = "Habilitar DDNS IPv4"
+
+[EnableIpv6]
+other = "Habilitar DDNS IPv6"
+
 [DDNSDomain]
 other = "Dominio DDNS"
 

--- a/resource/l10n/zh-CN.toml
+++ b/resource/l10n/zh-CN.toml
@@ -619,6 +619,12 @@ other = "在服务中显示"
 [EnableDDNS]
 other = "启用DDNS"
 
+[EnableIPv4]
+other = "启用DDNS IPv4"
+
+[EnableIpv6]
+other = "启用DDNS IPv6"
+
 [DDNSDomain]
 other = "DDNS域名"
 

--- a/resource/l10n/zh-TW.toml
+++ b/resource/l10n/zh-TW.toml
@@ -619,6 +619,12 @@ other = "在服務中顯示"
 [EnableDDNS]
 other = "啟用DDNS"
 
+[EnableIPv4]
+other = "啟用DDNS IPv4"
+
+[EnableIpv6]
+other = "啟用DDNS IPv6"
+
 [DDNSDomain]
 other = "DDNS網域"
 

--- a/resource/static/main.js
+++ b/resource/static/main.js
@@ -322,10 +322,15 @@ function addOrEditServer(server, conf) {
   } else {
     modal.find(".ui.hideforguest.checkbox").checkbox("set unchecked");
   }
-  if (server && server.EnableDDNS) {
-    modal.find(".ui.enableddns.checkbox").checkbox("set checked");
+  if (server && server.EnableIPv4) {
+    modal.find(".ui.enableipv4.checkbox").checkbox("set checked");
   } else {
-    modal.find(".ui.enableddns.checkbox").checkbox("set unchecked");
+    modal.find(".ui.enableipv4.checkbox").checkbox("set unchecked");
+  }
+  if (server && server.EnableIpv6) {
+    modal.find(".ui.enableipv6.checkbox").checkbox("set checked");
+  } else {
+    modal.find(".ui.enableipv6.checkbox").checkbox("set unchecked");
   }
   showFormModal(".server.modal", "#serverForm", "/api/server");
 }

--- a/resource/static/main.js
+++ b/resource/static/main.js
@@ -322,6 +322,11 @@ function addOrEditServer(server, conf) {
   } else {
     modal.find(".ui.hideforguest.checkbox").checkbox("set unchecked");
   }
+  if (server && server.EnableDDNS) {
+    modal.find(".ui.enableddns.checkbox").checkbox("set checked");
+  } else {
+    modal.find(".ui.enableddns.checkbox").checkbox("set unchecked");
+  }
   if (server && server.EnableIPv4) {
     modal.find(".ui.enableipv4.checkbox").checkbox("set checked");
   } else {

--- a/resource/template/common/footer.html
+++ b/resource/template/common/footer.html
@@ -10,7 +10,7 @@
 <script src="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-y/semantic-ui/2.4.1/semantic.min.js"></script>
 <script src="/static/semantic-ui-alerts.min.js"></script>
 <script src="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-y/vue/2.6.14/vue.min.js"></script>
-<script src="/static/main.js?v20240224"></script>
+<script src="/static/main.js?v20240330"></script>
 <script>
     (function () {
         updateLang({{.LANG }});

--- a/resource/template/component/server.html
+++ b/resource/template/component/server.html
@@ -33,6 +33,18 @@
                 </div>
             </div>
             <div class="field">
+                <div class="ui enableipv4 checkbox">
+                    <input name="EnableIPv4" type="checkbox" tabindex="0" />
+                    <label>{{tr "EnableIPv4"}}</label>
+                </div>
+            </div>
+            <div class="field">
+                <div class="ui enableipv6 checkbox">
+                    <input name="EnableIpv6" type="checkbox" tabindex="0" />
+                    <label>{{tr "EnableIpv6"}}</label>
+                </div>
+            </div>
+            <div class="field">
                 <label>{{tr "DDNSDomain"}}</label>
                 <input type="text" name="DDNSDomain" placeholder="{{tr "DDNSDomain"}}">
             </div>

--- a/resource/template/dashboard-default/server.html
+++ b/resource/template/dashboard-default/server.html
@@ -30,6 +30,8 @@
                     <th>{{tr "VersionNumber"}}</th>
                     <th>{{tr "HideForGuest"}}</th>
                     <th>{{tr "EnableDDNS"}}</th>
+                    <th>{{tr "EnableIPv4"}}</th>
+                    <th>{{tr "EnableIpv6"}}</th>
                     <th>{{tr "DDNSDomain"}}</th>
                     <th>{{tr "Secret"}}</th>
                     <th>{{tr "OneKeyInstall"}}</th>
@@ -48,6 +50,8 @@
                     <td>{{$server.Host.Version}}</td>
                     <td>{{$server.HideForGuest}}</td>
                     <td>{{$server.EnableDDNS}}</td>
+                    <td>{{$server.EnableIPv4}}</td>
+                    <td>{{$server.EnableIpv6}}</td>
                     <td>{{$server.DDNSDomain}}</td>
                     <td>
                         <button class="ui icon green mini button" data-clipboard-text="{{$server.Secret}}" data-tooltip="{{tr "ClickToCopy"}}">

--- a/resource/template/theme-angel-kanade/footer.html
+++ b/resource/template/theme-angel-kanade/footer.html
@@ -13,7 +13,7 @@
 <script src="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-y/semantic-ui/2.4.1/semantic.min.js"></script>
 <script src="/static/semantic-ui-alerts.min.js"></script>
 <script src="https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-y/vue/2.6.14/vue.min.js"></script>
-<script src="/static/main.js?v20240224"></script>
+<script src="/static/main.js?v20240330"></script>
 <script src="/static/theme-default/js/mixin.js?v20240302"></script>
 <script>
     (function () {

--- a/service/rpc/nezha.go
+++ b/service/rpc/nezha.go
@@ -127,8 +127,8 @@ func (s *NezhaHandler) ReportSystemInfo(c context.Context, r *pb.Host) (*pb.Rece
 			ipv4, ipv6, _ := utils.SplitIPAddr(host.IP)
 			maxRetries := int(singleton.Conf.DDNS.MaxRetries)
 			config := &ddns.DomainConfig{
-				EnableIPv4: true,
-				EnableIpv6: true,
+				EnableIPv4: singleton.ServerList[clientID].EnableIPv4,
+				EnableIpv6: singleton.ServerList[clientID].EnableIpv6,
 				FullDomain: serverDomain,
 				Ipv4Addr:   ipv4,
 				Ipv6Addr:   ipv6,


### PR DESCRIPTION
在服务器后台管理界面增加了每个服务器只更新ipv4或ipv6的选项，更改后需要同时勾选启用DDNS和DDNS ipv4或ipv6两个选项才能使DDNS生效（三个都选也可以，即和之前的效果一样）