### PR TITLE
修复ServerStatus主题Bug

### DIFF
--- a/resource/template/theme-server-status/header.html
+++ b/resource/template/theme-server-status/header.html
@@ -28,7 +28,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/js/bootstrap.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14"></script>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/echarts/map/js/world.js" integrity="sha256-gfuWPAoFfnPsyjIkcWLiB2Ik2d4/YOYoRQ6Bzh/pDk4=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/echarts/map/js/world.js"></script>
     <script src="/static/theme-server-status/js/mixin.js?v20240302"></script>
 </head>
 <body>

--- a/resource/template/theme-server-status/header.html
+++ b/resource/template/theme-server-status/header.html
@@ -28,7 +28,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/js/bootstrap.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14"></script>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/echarts/map/js/world.js" integrity="md5-ZmUzMzZlOGQyYzk2NTgwNGRlMzRlNTliZDgyYTY1OGUgIC0=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/echarts/map/js/world.js" integrity="sha256-gfuWPAoFfnPsyjIkcWLiB2Ik2d4/YOYoRQ6Bzh/pDk4=" crossorigin="anonymous"></script>
     <script src="/static/theme-server-status/js/mixin.js?v20240302"></script>
 </head>
 <body>

--- a/resource/template/theme-server-status/home.html
+++ b/resource/template/theme-server-status/home.html
@@ -123,6 +123,7 @@
                     console.log('init countryMapChartData not complete');
                     return;
                 }
+                const unit = this.language=='zh-CN' ? '台' : 'servers';
                 const isMobile = this.checkIsMobile();
                 const width = isMobile ? 338 : 1102;
                 const height = isMobile ? 200 : 500;
@@ -153,8 +154,7 @@
                         trigger: 'item',
                         formatter: function (params) {
                             if (params.data && params.data.value > 0) {
-                                const unit = this.language=='zh-CN' ? '台' : ' Servers';
-                                return params.name + ' ' + params.data.value + unit;
+                                return params.name + ' ' + params.data.value + ' ' + unit;
                             } else {
                                 return '';
                             }


### PR DESCRIPTION
1. ServerStatus主题integrity方式JS引入错误
<img width="754" alt="image" src="https://github.com/naiba/nezha/assets/144927971/718e7ff8-8fac-44fe-b794-6c8c808f82d6">

2. 修复点击点亮的地图时，弹出文案中英文区分未生效bug