### PR TITLE
:sparkles: 支持cloudflare access OIDC认证

### DIFF
--- a/cmd/dashboard/controller/guest_page.go
+++ b/cmd/dashboard/controller/guest_page.go
@@ -49,6 +49,9 @@ func (gp *guestPage) login(c *gin.Context) {
 	} else if singleton.Conf.Oauth2.Type == model.ConfigTypeGitea {
 		LoginType = "Gitea"
 		RegistrationLink = fmt.Sprintf("%s/user/sign_up", singleton.Conf.Oauth2.Endpoint)
+	} else if singleton.Conf.Oauth2.Type == model.ConfigTypeCloudflare {
+		LoginType = "Cloudflare"
+		RegistrationLink = "https://dash.cloudflare.com/sign-up/teams"
 	}
 	c.HTML(http.StatusOK, "dashboard-"+singleton.Conf.Site.DashboardTheme+"/login", mygin.CommonEnvironment(c, gin.H{
 		"Title":            singleton.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "Login"}),

--- a/model/config.go
+++ b/model/config.go
@@ -32,11 +32,12 @@ var DashboardThemes = map[string]string{
 }
 
 const (
-	ConfigTypeGitHub  = "github"
-	ConfigTypeGitee   = "gitee"
-	ConfigTypeGitlab  = "gitlab"
-	ConfigTypeJihulab = "jihulab"
-	ConfigTypeGitea   = "gitea"
+	ConfigTypeGitHub     = "github"
+	ConfigTypeGitee      = "gitee"
+	ConfigTypeGitlab     = "gitlab"
+	ConfigTypeJihulab    = "jihulab"
+	ConfigTypeGitea      = "gitea"
+	ConfigTypeCloudflare = "cloudflare"
 )
 
 const (

--- a/pkg/oidc/cloudflare/cloudflare.go
+++ b/pkg/oidc/cloudflare/cloudflare.go
@@ -1,0 +1,22 @@
+package cloudflare
+
+import (
+	"github.com/naiba/nezha/model"
+	"github.com/naiba/nezha/service/singleton"
+)
+
+type UserInfo struct {
+	Sub    string   `json:"sub"`
+	Email  string   `json:"email"`
+	Name   string   `json:"name"`
+	Groups []string `json:"groups"`
+}
+
+func (u UserInfo) MapToNezhaUser() model.User {
+	var user model.User
+	singleton.DB.Where("login = ?", u.Sub).First(&user)
+	user.Login = u.Sub
+	user.Email = u.Email
+	user.Name = u.Name
+	return user
+}


### PR DESCRIPTION
示例配置：
Admin:  ZeroTrust-MyTeam-Users-<具体用户>-UserID
ClientID与ClientSecret获取方式: ZeroTrust-Access-Applications-SaaS-OIDC


```yaml
Oauth2:
  Admin: 701b9ea6-9f56-48cd-af3e-cbb4bfc1475c
  ClientID: 3516291f53eca9b4901a01337e41be7dc52f565c8657d08a3fddb2178d13c5bf
  ClientSecret: 0568b67c7b6d0ed51c663e2fe935683007c28f947a27b7bd47a5ad3d8b56fb67
  Endpoint: "https://akkia.cloudflareaccess.com"
  Type: cloudflare
```