### PR TITLE
Update GPG key for libsepol

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -195,7 +195,7 @@ install_arch() {
     [yY][eE][sS] | [yY])
         useradd -m nezha-agent
         sed -i "$ a\nezha-agent ALL=(ALL ) NOPASSWD:ALL" /etc/sudoers
-        sudo -iu nezha-agent bash -c 'gpg --keyserver keys.gnupg.net --recv-keys BE22091E3EF62275;
+        sudo -iu nezha-agent bash -c 'gpg --keyserver keys.gnupg.net --recv-keys 4695881C254508D1;
                                         cd /tmp; git clone https://aur.archlinux.org/libsepol.git; cd libsepol; makepkg -si --noconfirm --asdeps; cd ..;
                                         git clone https://aur.archlinux.org/libselinux.git; cd libselinux; makepkg -si --noconfirm; cd ..;
                                         rm -rf libsepol libselinux'

--- a/script/install_en.sh
+++ b/script/install_en.sh
@@ -192,7 +192,7 @@ install_arch() {
     [yY][eE][sS] | [yY])
         useradd -m nezha-agent
         sed -i "$ a\nezha-agent ALL=(ALL ) NOPASSWD:ALL" /etc/sudoers
-        sudo -iu nezha-agent bash -c 'gpg --keyserver keys.gnupg.net --recv-keys BE22091E3EF62275;
+        sudo -iu nezha-agent bash -c 'gpg --keyserver keys.gnupg.net --recv-keys 4695881C254508D1;
                                         cd /tmp; git clone https://aur.archlinux.org/libsepol.git; cd libsepol; makepkg -si --noconfirm --asdeps; cd ..;
                                         git clone https://aur.archlinux.org/libselinux.git; cd libselinux; makepkg -si --noconfirm; cd ..;
                                         rm -rf libsepol libselinux'


### PR DESCRIPTION
在使用 Arch 安装 `libsepol` 和 `libselinux` 包时，当前脚本中的 GPG 公钥 `BE22091E3EF62275` 已不可用。本 PR 将公钥更新为 `4695881C254508D1`。

已在本地测试，确保安装过程顺利完成。

### 错误日志

```
==> 正在使用 gpg 验证源文件签名...
    libsepol-3.6.tar.gz ... 失败 (未知的公钥 4695881C254508D1)
==> 错误： 一个或多个 PGP 签名无法校验！
```