### PR TITLE
refactor: 默认主题首页优化和修复

### DIFF
--- a/resource/l10n/en-US.toml
+++ b/resource/l10n/en-US.toml
@@ -648,3 +648,6 @@ other = "Disable Switch Template in Frontend"
 
 [ServersOnWorldMap]
 other = "Servers On World Map"
+
+[Disabled]
+other = "Disabled"

--- a/resource/l10n/es-ES.toml
+++ b/resource/l10n/es-ES.toml
@@ -648,3 +648,6 @@ other = "Deshabilitar Cambio de Plantilla en Frontend"
 
 [ServersOnWorldMap]
 other = "Servidores en el mapa mundial"
+
+[Disabled]
+other = "Disabled"

--- a/resource/l10n/zh-CN.toml
+++ b/resource/l10n/zh-CN.toml
@@ -648,3 +648,6 @@ other = "禁止前台切换模板"
 
 [ServersOnWorldMap]
 other = "服务器世界分布图"
+
+[Disabled]
+other = "禁用"

--- a/resource/l10n/zh-TW.toml
+++ b/resource/l10n/zh-TW.toml
@@ -648,3 +648,6 @@ other = "禁止前台切換主題"
 
 [ServersOnWorldMap]
 other = "伺服器世界分布圖"
+
+[Disabled]
+other = "关闭"

--- a/resource/template/theme-default/home.html
+++ b/resource/template/theme-default/home.html
@@ -11,8 +11,8 @@
           @#(group.Tag!==''?group.Tag:'{{tr "Default"}}')#@
         </div>
         <div class="active content">
-          <div class="ui four stackable status cards">
-            <div v-for="server in group.data" :id="server.ID" class="ui card">
+          <div class="ui stackable status cards" :class="group.data.length > 3 ? 'four' : 'three'">
+            <div v-if="group.data.length" v-for="server in group.data" :id="server.ID" class="ui card">
               <div class="content" v-if="server.Host" style="margin-top: 10px; padding-bottom: 5px">
                 <div class="header">
                 <i style="width: 22px;border-radius: 4px;" :class="'fi fi-' + server.Host.CountryCode"></i>&nbsp;<i v-if='server.Host.Platform == "darwin"'
@@ -75,7 +75,7 @@
                       <div :class="formatPercent(server.live,server.State.SwapUsed, server.Host.SwapTotal).class">
                         <div class="bar"
                           :style="formatPercent(server.live,server.State.SwapUsed, server.Host.SwapTotal).style">
-                          <small>@#parseInt(server.State?server.State.SwapUsed/server.Host.SwapTotal*100:0)#@%</small>
+                          <small>@#parseInt(server.State&&server.Host.SwapTotal?server.State.SwapUsed/server.Host.SwapTotal*100:0)#@%</small>
                         </div>
                       </div>
                     </div>

--- a/resource/template/theme-default/home.html
+++ b/resource/template/theme-default/home.html
@@ -31,7 +31,7 @@
                     {{tr "MemUsed"}}:
                     @#formatByteSize(server.State.MemUsed)#@/@#formatByteSize(server.Host.MemTotal)#@<br />
                     {{tr "SwapUsed"}}:
-                    @#formatByteSize(server.State.SwapUsed)#@/@#formatByteSize(server.Host.SwapTotal)#@<br />
+                    @#server.State&&server.Host.SwapTotal?formatByteSize(server.State.SwapUsed)+'/'+formatByteSize(server.Host.SwapTotal):tr "Disabled"#@<br />
                     {{tr "NetTransfer"}}: <i
                       class="arrow alternate circle down outline icon"></i>@#formatByteSize(server.State.NetInTransfer)#@<i
                       class="arrow alternate circle up outline icon"></i>@#formatByteSize(server.State.NetOutTransfer)#@<br />
@@ -72,10 +72,10 @@
                     </div>
                     <div class="three wide column">{{tr "SwapUsed"}}</div>
                     <div class="thirteen wide column">
-                      <div :class="formatPercent(server.live,server.State.SwapUsed, server.Host.SwapTotal).class">
+                      <div :class="formatPercent(server.live, server.State.SwapUsed, server.Host.SwapTotal).class">
                         <div class="bar"
-                          :style="formatPercent(server.live,server.State.SwapUsed, server.Host.SwapTotal).style">
-                          <small>@#parseInt(server.State&&server.Host.SwapTotal?server.State.SwapUsed/server.Host.SwapTotal*100:0)#@%</small>
+                          :style="formatPercent(server.live, server.State.SwapUsed, server.Host.SwapTotal).style">
+                          <small>@#server.State&&server.Host.SwapTotal?parseInt(server.State.SwapUsed/server.Host.SwapTotal*100+'%'):tr "Disabled"#@</small>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
1、优化默认主题服务器列表每行由默认的 4 格改为 3 格（我只有 3 台的时候默认 4 台会有空缺，修改后 3 台时会铺满，4 台时还按每行 4 台来展示）。
2、修复 swap 未开启时显示 NaN% 的问题。