### PR TITLE
ci: using time/tzdata package to provide zoneinfo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
           v: true
           x: false
           race: false
+          tags: timetzdata
           ldflags: -s -w --extldflags '-static -fpic' -X github.com/naiba/nezha/service/singleton.Version=${{ steps.extract_branch.outputs.tag }}
           buildmode: default
 

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -33,6 +33,7 @@ jobs:
           v: true
           x: false
           race: false
+          tags: timetzdata
           ldflags: -s -w --extldflags '-static -fpic' -X github.com/naiba/nezha/service/singleton.Version=test
           buildmode: default
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,5 +40,6 @@ jobs:
           v: true
           x: false
           race: false
+          tags: timetzdata
           ldflags: -s -w --extldflags '-static -fpic' -X github.com/naiba/nezha/service/singleton.Version=test
           buildmode: default

--- a/script/install_en.sh
+++ b/script/install_en.sh
@@ -182,7 +182,7 @@ before_show_menu() {
 
 install_base() {
     (command -v git >/dev/null 2>&1 && command -v curl >/dev/null 2>&1 && command -v wget >/dev/null 2>&1 && command -v unzip >/dev/null 2>&1 && command -v getenforce >/dev/null 2>&1) ||
-        (install_soft curl wget git unzip tzdata)
+        (install_soft curl wget git unzip)
 }
 
 install_arch() {


### PR DESCRIPTION
使用 go 内置的 `time/tzdata` 包提供时区信息，以避免安装额外的 `tzdata` 依赖包，并解决 Windows 默认没有内置时区数据导致无法启动 Dashboard 的问题。