### PR TITLE
Hide DDNS domain info for guests

### DIFF
--- a/service/singleton/server.go
+++ b/service/singleton/server.go
@@ -53,7 +53,9 @@ func ReSortServer() {
 	for _, s := range ServerList {
 		SortedServerList = append(SortedServerList, s)
 		if !s.HideForGuest {
-			SortedServerListForGuest = append(SortedServerListForGuest, s)
+			filteredStat := *s
+			filteredStat.DDNSDomain = "redacted"
+			SortedServerListForGuest = append(SortedServerListForGuest, &filteredStat)
 		}
 	}
 


### PR DESCRIPTION
为游客隐藏了DDNS域名信息，DDNS域名对一些人来说属于敏感信息，并可能泄漏机器ip，所以不应该被游客访问