### PR TITLE
Temporary fix for DDNSDomain leaks

### DIFF
--- a/cmd/dashboard/controller/common_page.go
+++ b/cmd/dashboard/controller/common_page.go
@@ -238,9 +238,16 @@ func (cp *commonPage) getServerStat(c *gin.Context) ([]byte, error) {
 			servers = singleton.SortedServerListForGuest
 		}
 
+		filteredServers := make([]*model.Server, len(servers))
+		for i, server := range servers {
+			filteredServer := *server
+			filteredServer.DDNSDomain = "redacted"
+			filteredServers[i] = &filteredServer
+		}
+
 		return utils.Json.Marshal(Data{
 			Now:     time.Now().Unix() * 1000,
-			Servers: servers,
+			Servers: filteredServers,
 		})
 	})
 	return v.([]byte), err

--- a/service/singleton/server.go
+++ b/service/singleton/server.go
@@ -53,9 +53,7 @@ func ReSortServer() {
 	for _, s := range ServerList {
 		SortedServerList = append(SortedServerList, s)
 		if !s.HideForGuest {
-			filteredStat := *s
-			filteredStat.DDNSDomain = "redacted"
-			SortedServerListForGuest = append(SortedServerListForGuest, &filteredStat)
+			SortedServerListForGuest = append(SortedServerListForGuest, s)
 		}
 	}
 


### PR DESCRIPTION
~直接操作DDNSDomain看来是不行，等以后找到合适的方法再改吧，只能建议现在不要用ddns功能，一定要用的话把游客隐藏打开~