### PR TITLE
优化gpu前端展示代码

### DIFF
--- a/resource/template/theme-angel-kanade/home.html
+++ b/resource/template/theme-angel-kanade/home.html
@@ -26,9 +26,6 @@
                   CPU: @#server.Host.CPU#@<br />
                   <template v-if="server.Host.GPU">
                       GPU: @#server.Host.GPU#@
-                      <span v-if="server.State.GPU >= 0">(@#server.State.GPU#@%)</span>
-                      <span v-else>(0%)</span>
-                      <br />
                   </template>
                   {{tr "DiskUsed"}}:
                   @#formatByteSize(server.State.DiskUsed)#@/@#formatByteSize(server.Host.DiskTotal)#@<br />

--- a/resource/template/theme-angel-kanade/home.html
+++ b/resource/template/theme-angel-kanade/home.html
@@ -24,7 +24,12 @@
                   [<span
                     v-if="server.Host.Virtualization">@#server.Host.Virtualization#@:</span>@#server.Host.Arch#@]<br />
                   CPU: @#server.Host.CPU#@<br />
-                  GPU: @#server.Host.GPU#@<br />
+                  <template v-if="server.Host.GPU">
+                      GPU: @#server.Host.GPU#@
+                      <span v-if="server.State.GPU >= 0">(@#server.State.GPU#@%)</span>
+                      <span v-else>(0%)</span>
+                      <br />
+                  </template>
                   {{tr "DiskUsed"}}:
                   @#formatByteSize(server.State.DiskUsed)#@/@#formatByteSize(server.Host.DiskTotal)#@<br />
                   {{tr "MemUsed"}}:

--- a/resource/template/theme-default/home.html
+++ b/resource/template/theme-default/home.html
@@ -30,8 +30,6 @@
                                         <br />
                                         <template v-if="server.Host.GPU">
                                             GPU: @#server.Host.GPU#@
-                                            <span v-if="server.State.GPU >= 0">(@#server.State.GPU#@%)</span>
-                                            <span v-else>(0%)</span>
                                             <br />
                                         </template>
                                         {{tr "DiskUsed"}}:

--- a/resource/template/theme-default/home.html
+++ b/resource/template/theme-default/home.html
@@ -28,8 +28,12 @@
                                         <br />
                                         CPU: @#server.Host.CPU#@
                                         <br />
-                                        GPU: @#server.Host.GPU#@
-                                        <br />
+                                        <template v-if="server.Host.GPU">
+                                            GPU: @#server.Host.GPU#@
+                                            <span v-if="server.State.GPU >= 0">(@#server.State.GPU#@%)</span>
+                                            <span v-else>(0%)</span>
+                                            <br />
+                                        </template>
                                         {{tr "DiskUsed"}}:
                                         @#formatByteSize(server.State.DiskUsed)#@/@#formatByteSize(server.Host.DiskTotal)#@
                                         <br />

--- a/resource/template/theme-server-status/home-group-false.html
+++ b/resource/template/theme-server-status/home-group-false.html
@@ -76,7 +76,7 @@
                         <span class="node-cell-expand" v-if="node.host.GPU">
                             <span class="node-cell-expand-label">GPU:</span>
                             @#node.host.GPU.join(",")#@ 
-                            <span v-if="node.State.GPU >= 0">(@#node.State.GPU#@%)</span>
+                            <span v-if="node.state.GPU >= 0">(@#node.state.GPU#@%)</span>
                             <span v-else>(0%)</span>
                         </span>
                         <span class="node-cell-expand">

--- a/resource/template/theme-server-status/home-group-false.html
+++ b/resource/template/theme-server-status/home-group-false.html
@@ -75,7 +75,9 @@
                         </span>
                         <span class="node-cell-expand" v-if="node.host.GPU">
                             <span class="node-cell-expand-label">GPU:</span>
-                            @#node.host.GPU.join(",")#@ (@#node.gpu.percent#@%)
+                            @#node.host.GPU.join(",")#@ 
+                            <span v-if="node.State.GPU >= 0">(@#node.State.GPU#@%)</span>
+                            <span v-else>(0%)</span>
                         </span>
                         <span class="node-cell-expand">
                             <span class="node-cell-expand-label">{{tr "DiskUsed"}}:</span>

--- a/resource/template/theme-server-status/home-group-false.html
+++ b/resource/template/theme-server-status/home-group-false.html
@@ -76,8 +76,7 @@
                         <span class="node-cell-expand" v-if="node.host.GPU">
                             <span class="node-cell-expand-label">GPU:</span>
                             @#node.host.GPU.join(",")#@ 
-                            <span v-if="node.state.GPU >= 0">(@#node.state.GPU#@%)</span>
-                            <span v-else>(0%)</span>
+                            (@#parseInt(node.state.GPU >=0 ? node.state.GPU : 0)#@%)
                         </span>
                         <span class="node-cell-expand">
                             <span class="node-cell-expand-label">{{tr "DiskUsed"}}:</span>

--- a/resource/template/theme-server-status/home-group-true.html
+++ b/resource/template/theme-server-status/home-group-true.html
@@ -78,7 +78,9 @@
                         </span>
                         <span class="node-cell-expand" v-if="node.host.GPU">
                             <span class="node-cell-expand-label">GPU:</span>
-                            @#node.host.GPU.join(",")#@ (@#node.gpu.percent#@%)
+                            @#node.host.GPU.join(",")#@ 
+                            <span v-if="node.State.GPU >= 0">(@#node.State.GPU#@%)</span>
+                            <span v-else>(0%)</span>
                         </span>
                         <span class="node-cell-expand">
                             <span class="node-cell-expand-label">{{tr "DiskUsed"}}:</span>

--- a/resource/template/theme-server-status/home-group-true.html
+++ b/resource/template/theme-server-status/home-group-true.html
@@ -79,7 +79,7 @@
                         <span class="node-cell-expand" v-if="node.host.GPU">
                             <span class="node-cell-expand-label">GPU:</span>
                             @#node.host.GPU.join(",")#@ 
-                            <span v-if="node.State.GPU >= 0">(@#node.State.GPU#@%)</span>
+                            <span v-if="node.state.GPU >= 0">(@#node.state.GPU#@%)</span>
                             <span v-else>(0%)</span>
                         </span>
                         <span class="node-cell-expand">

--- a/resource/template/theme-server-status/home-group-true.html
+++ b/resource/template/theme-server-status/home-group-true.html
@@ -79,8 +79,7 @@
                         <span class="node-cell-expand" v-if="node.host.GPU">
                             <span class="node-cell-expand-label">GPU:</span>
                             @#node.host.GPU.join(",")#@ 
-                            <span v-if="node.state.GPU >= 0">(@#node.state.GPU#@%)</span>
-                            <span v-else>(0%)</span>
+                            (@#parseInt(node.state.GPU >=0 ? node.state.GPU : 0)#@%)
                         </span>
                         <span class="node-cell-expand">
                             <span class="node-cell-expand-label">{{tr "DiskUsed"}}:</span>

--- a/resource/template/theme-server-status/home.html
+++ b/resource/template/theme-server-status/home.html
@@ -396,7 +396,6 @@
                         network: this.getNetworkSpeed(server.State.NetInSpeed, server.State.NetOutSpeed),
                         traffic: this.formatByteSize(server.State.NetInTransfer) + ' | ' + this.formatByteSize(server.State.NetOutTransfer),
                         cpu: this.formatPercents(server.live, this.toFixed2(server.State.CPU)),
-                        gpu: this.formatPercents(server.live, this.toFixed2(server.State.GPU)),
                         memory: this.formatPercent(server.live, server.State.MemUsed, server.Host.MemTotal),
                         hdd: this.formatPercent(server.live, server.State.DiskUsed, server.Host.DiskTotal),
                         online: server.live,


### PR DESCRIPTION
测试地址
https://dev.nezha.pp.ua/

## default 主题
### 有gpu监控项
<img width="293" alt="image" src="https://github.com/naiba/nezha/assets/144927971/0fa90843-9320-46f3-9e8c-0ca4e2658a81">

### 没有gpu监控项
<img width="289" alt="image" src="https://github.com/naiba/nezha/assets/144927971/7c69496b-acae-4777-9c0c-308422f8167c">

## server-status 主题,
### 有gpu监控项
<img width="546" alt="image" src="https://github.com/naiba/nezha/assets/144927971/959515d5-23ac-43e3-8830-cce573397c72">

### 没有gpu监控项
<img width="466" alt="image" src="https://github.com/naiba/nezha/assets/144927971/8ff773f2-1eb8-4399-be79-bbef56e391f7">

## AngelKanade主题
### 有gpu监控项
<img width="467" alt="image" src="https://github.com/naiba/nezha/assets/144927971/31f7ef16-3418-40c7-98c4-db49d9d02018">

### 没有gpu监控项
<img width="472" alt="image" src="https://github.com/naiba/nezha/assets/144927971/cb5701a7-d2ef-422c-a3cc-6ff8d48bee7b">


