### PR TITLE
优化server-status主题首页网络图表

### DIFF
--- a/resource/template/theme-server-status/home.html
+++ b/resource/template/theme-server-status/home.html
@@ -533,6 +533,21 @@
                         connectNulls: true
                     };
                 });
+
+                const legendData = chartData.map(item => item.monitor_name);
+                const maxLegendsPerRowMobile = localStorage.getItem("maxLegendsPerRowMobile") ? localStorage.getItem("maxLegendsPerRowMobile") : 3;
+                const maxLegendsPerRowPc = localStorage.getItem("maxLegendsPerRowPc") ? localStorage.getItem("maxLegendsPerRowPc") : 6;
+                const autoIncrement = Math.floor((legendData.length - 1) / (isMobile ? maxLegendsPerRowMobile : maxLegendsPerRowPc)) * (isMobile ? 20 : 28)
+                const height = 300 + autoIncrement;
+                const gridTop = 40 + autoIncrement;
+                const legendIcon = isMobile ? 'rect' : ""; 
+                const itemWidth = isMobile ? 10 : 25;
+                const itemHeight = isMobile ? 10 : 14;
+                chart.resize({
+                    width: 'auto',
+                    height: height
+                });
+
                 const option = {
                     backgroundColor: backgroundColor,
                     title: {
@@ -548,8 +563,9 @@
                         }
                     },
                     legend: {
-                        data: chartData.map(item => item.monitor_name),
+                        data: legendData,
                         show: true,
+                        icon: legendIcon,
                         textStyle: {
                             fontSize: fontSize,
                             color: fontColor
@@ -557,7 +573,9 @@
                         top: legendTop,
                         bottom: 0,
                         left: legendLeft,
-                        padding: legendPadding
+                        padding: legendPadding,
+                        itemWidth: itemWidth,
+                        itemHeight: itemHeight,
                     },
                     xAxis: {
                         type: 'time',
@@ -589,7 +607,7 @@
                         color: fontColor
                     },
                     grid: {
-                        top: '40',
+                        top: gridTop,
                         left: gridLeft,
                         right: gridRight
                     }


### PR DESCRIPTION
## 根据检测点数量自动适配legend高度,
默认值：pc端6个Legends换行，移动端3个legends换行
自定义：在哪吒后台->设置->自定义代码，修改默认数字后，粘贴代码并保存，可改变默认值。
```
<script>
// pc端Legends默认值，设置成了4
if(!localStorage.getItem("maxLegendsPerRowPc")){
localStorage.setItem("maxLegendsPerRowPc", 4);
}
// 移动端Legends默认值，设置成了2
if(!localStorage.getItem("maxLegendsPerRowMobile")){
localStorage.setItem("maxLegendsPerRowMobile", '2');
}
</script>
```

## 效果对比

### 移动端
<img width="308" alt="image" src="https://github.com/naiba/nezha/assets/144927971/d2b0f4b6-c50e-4e8a-92eb-75091e4e912b">

<img width="308" alt="image" src="https://github.com/naiba/nezha/assets/144927971/6d099c94-261e-43bd-94c4-f6ab816d8f00">

### pc端
<img width="1186" alt="image" src="https://github.com/naiba/nezha/assets/144927971/123163f3-bbf5-45e7-bb1d-08dd9faf9098">
<img width="1216" alt="image" src="https://github.com/naiba/nezha/assets/144927971/e43492df-7aca-4314-b502-d037b89958d1">
