### PR TITLE
Update IP location service in install scripts

### DIFF
--- a/script/install.command
+++ b/script/install.command
@@ -28,8 +28,8 @@ pre_check() {
 
     ## China_IP
     if [[ -z "${CN}" ]]; then
-        if [[ $(curl -m 10 -s https://ipapi.co/json | grep 'China') != "" ]]; then
-            echo "According to the information provided by ipapi.co, the current IP may be in China"
+        if [[ $(curl -m 10 -s http://ip-api.com/json |grep 'country' |grep -q 'China') != "" ]]; then
+            echo "According to the information provided by ip-api.com, the current IP may be in China"
             read -e -r -p "Is the installation done with a Chinese Mirror? [Y/n] (Custom Mirror Input 3):" input
             case $input in
             [yY][eE][sS] | [yY])

--- a/script/install.sh
+++ b/script/install.sh
@@ -66,8 +66,8 @@ pre_check() {
 
     ## China_IP
     if [ -z "$CN" ]; then
-        if curl -m 10 -s https://ipapi.co/json | grep -q 'China'; then
-            echo "根据ipapi.co提供的信息，当前IP可能在中国"
+        if curl -m 10 -s http://ip-api.com/json |grep 'country' |grep -q 'China'; then
+            echo "根据ip-api.com提供的信息，当前IP可能在中国"
             printf "是否选用中国镜像完成安装? [Y/n] (自定义镜像输入 3):"
             read -r input
             case $input in

--- a/script/install_en.sh
+++ b/script/install_en.sh
@@ -66,8 +66,8 @@ pre_check() {
 
     ## China_IP
     if [ -z "$CN" ]; then
-        if curl -m 10 -s https://ipapi.co/json | grep -q 'China'; then
-            echo "According to the information provided by ipapi.co, the current IP may be in China"
+        if curl -m 10 -s http://ip-api.com/json |grep 'country' |grep -q 'China'; then
+            echo "According to the information provided by ip-api.com, the current IP may be in China"
             printf "Will the installation be done with a Chinese Mirror? [Y/n] (Custom Mirror Input 3): "
             read -r input
             case $input in


### PR DESCRIPTION
The install scripts previously used ipapi.co to determine if the user's IP was located in China. This commit changes the service to ipinfo.io, updating the curl commands and printed messages accordingly. This should improve geographical accuracy when determining whether to use a Chinese mirror for installation.