### PR TITLE
fix: concurrent write to single WebSocket connection

### DIFF
--- a/model/monitor.go
+++ b/model/monitor.go
@@ -120,7 +120,7 @@ func (m *Monitor) AfterFind(tx *gorm.DB) error {
 
 // IsServiceSentinelNeeded 判断该任务类型是否需要进行服务监控 需要则返回true
 func IsServiceSentinelNeeded(t uint64) bool {
-	return t != TaskTypeCommand && t != TaskTypeTerminal && t != TaskTypeUpgrade
+	return t != TaskTypeCommand && t != TaskTypeTerminalGRPC && t != TaskTypeUpgrade
 }
 
 func (m *Monitor) InitSkipServers() error {

--- a/pkg/websocketx/safe_conn.go
+++ b/pkg/websocketx/safe_conn.go
@@ -28,6 +28,12 @@ func (conn *Conn) Write(data []byte) (int, error) {
 	return len(data), nil
 }
 
+func (conn *Conn) WriteMessage(messageType int, data []byte) error {
+	conn.writeLock.Lock()
+	defer conn.writeLock.Unlock()
+	return conn.Conn.WriteMessage(messageType, data)
+}
+
 func (conn *Conn) Read(data []byte) (int, error) {
 	if len(conn.dataBuf) > 0 {
 		n := copy(data, conn.dataBuf)


### PR DESCRIPTION
`conn.WriteMessage` is not thread-safe itself, hence adding a write lock to prevent concurrent write.

Other fixes:
- fix `monitor.IsServiceSentinelNeeded` logic (renamed TaskTypeTerminal to TaskTypeTerminalGRPC, as the former is deprecated)

Tested on my own machine and a team member's.