### PR TITLE
installer: improve region detection reliability using CDN APIs

### DIFF
--- a/script/install.ps1
+++ b/script/install.ps1
@@ -49,8 +49,20 @@ if ([string]::IsNullOrWhiteSpace($agenttag)) {
     }
 }
 #Region判断
-$ipapi= Invoke-RestMethod  -Uri "https://api.myip.com/" -UserAgent "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.1 (KHTML, like Gecko) Chrome/14.0.835.163 Safari/535.1"
-$region=$ipapi.cc
+$ipapi = ""
+$region = "Unknown"
+foreach ($url in ("https://dash.cloudflare.com/cdn-cgi/trace","https://cf-ns.com/cdn-cgi/trace","https://1.0.0.1/cdn-cgi/trace")) {
+    try {
+        $ipapi = Invoke-RestMethod -Uri $url -TimeoutSec 5 -UseBasicParsing
+        if ($ipapi -match "loc=(\w+)" ) {
+            $region = $Matches[1]
+            break
+        }
+    }
+    catch {
+        Write-Host "Error occurred while querying $url : $_"
+    }
+}
 echo $ipapi
 if($region -ne "CN"){
 $download = "https://github.com/$agentrepo/releases/download/$agenttag/$file"


### PR DESCRIPTION
使用Cloudflare CDN判断地理位置从而选择下载服务器

之前所使用的属地API在国内无法连接，更换为Cloudflare CDN节点可以避免这个问题

- https://dash.cloudflare.com/cdn-cgi/trace
- https://cf-ns.com/cdn-cgi/trace
- https://1.0.0.1/cdn-cgi/trace

![](https://github.com/user-attachments/assets/ea1aead5-0a8a-4c0d-bc7b-3aedc1917d0b)

使用了全球Anycast、国内京东云合作多条线路，避免因网络连通性问题导致获取不了位置的情况

实测效果：

![](https://github.com/user-attachments/assets/76df2b0f-431e-4475-a068-8d4b3767f34f)
