### PR TITLE
chore: missing gpu info line break in theme-angel-kanade

### DIFF
--- a/resource/template/theme-angel-kanade/home.html
+++ b/resource/template/theme-angel-kanade/home.html
@@ -27,6 +27,7 @@
                   <template v-if="server.Host.GPU">
                       GPU: @#server.Host.GPU#@
                   </template>
+                  <br />
                   {{tr "DiskUsed"}}:
                   @#formatByteSize(server.State.DiskUsed)#@/@#formatByteSize(server.Host.DiskTotal)#@<br />
                   {{tr "MemUsed"}}:

--- a/resource/template/theme-angel-kanade/home.html
+++ b/resource/template/theme-angel-kanade/home.html
@@ -25,9 +25,8 @@
                     v-if="server.Host.Virtualization">@#server.Host.Virtualization#@:</span>@#server.Host.Arch#@]<br />
                   CPU: @#server.Host.CPU#@<br />
                   <template v-if="server.Host.GPU">
-                      GPU: @#server.Host.GPU#@
+                      GPU: @#server.Host.GPU#@<br />
                   </template>
-                  <br />
                   {{tr "DiskUsed"}}:
                   @#formatByteSize(server.State.DiskUsed)#@/@#formatByteSize(server.Host.DiskTotal)#@<br />
                   {{tr "MemUsed"}}:


### PR DESCRIPTION
Previous:
<img width="262" alt="image" src="https://github.com/user-attachments/assets/a62ade00-9287-4b64-ac0a-2f312ff743cc">

After:
<img width="268" alt="image" src="https://github.com/user-attachments/assets/9384ed5e-8253-4c9a-88a1-535b87c5cc54">
