### PR TITLE
Default主题fixbug

### DIFF
--- a/resource/static/manifest-en-US.json
+++ b/resource/static/manifest-en-US.json
@@ -15,13 +15,13 @@
             "purpose": "maskable"
         },
         {
-            "src": "//static/manifest-512x512.png",
+            "src": "/static/manifest-512x512.png",
             "sizes": "512x512",
             "type": "image/png",
             "purpose": "any"
         },
         {
-            "src": "//static/manifest-512x512.png",
+            "src": "/static/manifest-512x512.png",
             "sizes": "512x512",
             "type": "image/png",
             "purpose": "maskable"

--- a/resource/template/theme-default/header.html
+++ b/resource/template/theme-default/header.html
@@ -3,6 +3,7 @@
 <html lang="{{.Conf.Language}}">
 
 <head>
+    <title>{{ .Title }}</title>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <meta content="telephone=no" name="format-detection">

--- a/resource/template/theme-default/header.html
+++ b/resource/template/theme-default/header.html
@@ -9,6 +9,7 @@
     <meta content="telephone=no" name="format-detection">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="theme-color" content="#000000" />
     {{ if eq .Conf.Language "zh-CN" }}
         <link rel="manifest" href="/static/manifest-zh-CN.json?v20240905" />

--- a/resource/template/theme-default/home.html
+++ b/resource/template/theme-default/home.html
@@ -194,7 +194,7 @@
             ]
         },
         mixins: [mixinsVue],
-            created() {
+        created() {
             this.servers = JSON.parse('{{.Servers}}').servers;
             this.group()
         },

--- a/resource/template/theme-default/network.html
+++ b/resource/template/theme-default/network.html
@@ -232,7 +232,7 @@
                 this.option.legend.data = tLegendData;
                 const maxLegendsPerRowMobile = localStorage.getItem("maxLegendsPerRowMobile") ? localStorage.getItem("maxLegendsPerRowMobile") : 2;
                 const maxLegendsPerRowPc = localStorage.getItem("maxLegendsPerRowPc") ? localStorage.getItem("maxLegendsPerRowPc") : 5;
-                const autoIncrement = Math.floor((tLegendData.length - 1) / (this.isMobile ? maxLegendsPerRowMobile : maxLegendsPerRowPc)) * (this.isMobile ? 40 : 60);
+                const autoIncrement = Math.floor((tLegendData.length - 1) / (this.isMobile ? maxLegendsPerRowMobile : maxLegendsPerRowPc)) * (this.isMobile ? 28 : 30);
                 const height = 520 + autoIncrement;
                 const gridTop = 60 + autoIncrement;
                 this.option.grid = {

--- a/resource/template/theme-default/network.html
+++ b/resource/template/theme-default/network.html
@@ -36,7 +36,11 @@
             defaultTemplate: {{.Conf.Site.Theme}},
             templates: {{.Themes}},
             servers: initData,
-            option: {
+            option: {}
+        },
+        mixins: [mixinsVue],
+        created() {
+            this.option = {
                 tooltip: {
                     trigger: 'axis',
                     position: function (pt) {
@@ -69,15 +73,6 @@
                     right: this.isMobile ? '8%' : '3.8%',
                 },
                 backgroundColor: '',
-                toolbox: {
-                    feature: {
-                        dataZoom: {
-                            yAxisIndex: 'none'
-                        },
-                        restore: {},
-                        saveAsImage: {}
-                    }
-                },
                 dataZoom: [
                     {
                         type: 'slider',
@@ -94,10 +89,8 @@
                     boundaryGap: false
                 },
                 series: [],
-            },
-            chartOnOff: true,
+            }
         },
-        mixins: [mixinsVue],
         mounted() {
             this.renderChart();
             this.parseMonitorInfo(monitorInfo);
@@ -237,6 +230,20 @@
                 this.option.title.text = monitorInfo.result[0].server_name;
                 this.option.series = tSeries;
                 this.option.legend.data = tLegendData;
+                const maxLegendsPerRowMobile = localStorage.getItem("maxLegendsPerRowMobile") ? localStorage.getItem("maxLegendsPerRowMobile") : 2;
+                const maxLegendsPerRowPc = localStorage.getItem("maxLegendsPerRowPc") ? localStorage.getItem("maxLegendsPerRowPc") : 3;
+                const autoIncrement = Math.floor((tLegendData.length - 1) / (this.isMobile ? maxLegendsPerRowMobile : maxLegendsPerRowPc)) * (this.isMobile ? 40 : 40);
+                const height = 520 + autoIncrement;
+                const gridTop = 40 + autoIncrement;
+                this.option.grid = {
+                    left: this.isMobile ? '8%' : '3.8%',
+                    right: this.isMobile ? '8%' : '3.8%',
+                    top: gridTop
+                };
+                this.myChart.resize({
+                    width: 'auto',
+                    height: height
+                });
                 this.myChart.clear();
                 this.myChart.setOption(this.option);
             },

--- a/resource/template/theme-default/network.html
+++ b/resource/template/theme-default/network.html
@@ -231,8 +231,8 @@
                 this.option.series = tSeries;
                 this.option.legend.data = tLegendData;
                 const maxLegendsPerRowMobile = localStorage.getItem("maxLegendsPerRowMobile") ? localStorage.getItem("maxLegendsPerRowMobile") : 2;
-                const maxLegendsPerRowPc = localStorage.getItem("maxLegendsPerRowPc") ? localStorage.getItem("maxLegendsPerRowPc") : 3;
-                const autoIncrement = Math.floor((tLegendData.length - 1) / (this.isMobile ? maxLegendsPerRowMobile : maxLegendsPerRowPc)) * (this.isMobile ? 40 : 40);
+                const maxLegendsPerRowPc = localStorage.getItem("maxLegendsPerRowPc") ? localStorage.getItem("maxLegendsPerRowPc") : 5;
+                const autoIncrement = Math.floor((tLegendData.length - 1) / (this.isMobile ? maxLegendsPerRowMobile : maxLegendsPerRowPc)) * (this.isMobile ? 40 : 60);
                 const height = 520 + autoIncrement;
                 const gridTop = 40 + autoIncrement;
                 this.option.grid = {

--- a/resource/template/theme-default/network.html
+++ b/resource/template/theme-default/network.html
@@ -234,7 +234,7 @@
                 const maxLegendsPerRowPc = localStorage.getItem("maxLegendsPerRowPc") ? localStorage.getItem("maxLegendsPerRowPc") : 5;
                 const autoIncrement = Math.floor((tLegendData.length - 1) / (this.isMobile ? maxLegendsPerRowMobile : maxLegendsPerRowPc)) * (this.isMobile ? 40 : 60);
                 const height = 520 + autoIncrement;
-                const gridTop = 40 + autoIncrement;
+                const gridTop = 60 + autoIncrement;
                 this.option.grid = {
                     left: this.isMobile ? '8%' : '3.8%',
                     right: this.isMobile ? '8%' : '3.8%',

--- a/resource/template/theme-default/network.html
+++ b/resource/template/theme-default/network.html
@@ -231,7 +231,7 @@
                 this.option.series = tSeries;
                 this.option.legend.data = tLegendData;
                 const maxLegendsPerRowMobile = localStorage.getItem("maxLegendsPerRowMobile") ? localStorage.getItem("maxLegendsPerRowMobile") : 2;
-                const maxLegendsPerRowPc = localStorage.getItem("maxLegendsPerRowPc") ? localStorage.getItem("maxLegendsPerRowPc") : 5;
+                const maxLegendsPerRowPc = localStorage.getItem("maxLegendsPerRowPc") ? localStorage.getItem("maxLegendsPerRowPc") : 6;
                 const autoIncrement = Math.floor((tLegendData.length - 1) / (this.isMobile ? maxLegendsPerRowMobile : maxLegendsPerRowPc)) * (this.isMobile ? 28 : 34);
                 const height = 520 + autoIncrement;
                 const gridTop = 60 + autoIncrement;

--- a/resource/template/theme-default/network.html
+++ b/resource/template/theme-default/network.html
@@ -232,7 +232,7 @@
                 this.option.legend.data = tLegendData;
                 const maxLegendsPerRowMobile = localStorage.getItem("maxLegendsPerRowMobile") ? localStorage.getItem("maxLegendsPerRowMobile") : 2;
                 const maxLegendsPerRowPc = localStorage.getItem("maxLegendsPerRowPc") ? localStorage.getItem("maxLegendsPerRowPc") : 5;
-                const autoIncrement = Math.floor((tLegendData.length - 1) / (this.isMobile ? maxLegendsPerRowMobile : maxLegendsPerRowPc)) * (this.isMobile ? 28 : 30);
+                const autoIncrement = Math.floor((tLegendData.length - 1) / (this.isMobile ? maxLegendsPerRowMobile : maxLegendsPerRowPc)) * (this.isMobile ? 28 : 34);
                 const height = 520 + autoIncrement;
                 const gridTop = 60 + autoIncrement;
                 this.option.grid = {

--- a/resource/template/theme-server-status/header.html
+++ b/resource/template/theme-server-status/header.html
@@ -8,6 +8,7 @@
     <meta content="telephone=no" name="format-detection">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="theme-color" content="#000000" />
     {{if eq .Conf.Language "zh-CN"}}
         <link rel="manifest" href="/static/manifest-zh-CN.json?v20240905" />


### PR DESCRIPTION
1.补上上个pr误删的网页title
2.修复network页纵坐标数值显示不全
3.修复network，多个legend导致的遮挡主图表问题，默认设置为，
移动端：每2个legend元素增加28px
pc端： 每6个元素增加34px
修改默认设置的方法，后台设置，增加自定义代码

```
<script>
localStorage.setItem("maxLegendsPerRowPc", 4); //pc端设置为每4个legend元素增加28px
localStorage.setItem("maxLegendsPerRowMobile", '3');  //移动端设置为每3个legend元素增加28px
</script>
```

演示地址： https://dev.nezha.pp.ua/network