### PR TITLE
在主脚本中移除installation_check

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -885,7 +885,6 @@ show_menu() {
 }
 
 pre_check
-installation_check
 
 if [ $# -gt 0 ]; then
     case $1 in

--- a/script/install_en.sh
+++ b/script/install_en.sh
@@ -879,7 +879,6 @@ show_menu() {
 }
 
 pre_check
-installation_check
 
 if [ $# -gt 0 ]; then
     case $1 in


### PR DESCRIPTION
在安装agent的时候，我们也许不需要安装docker。但是当前脚本如果没有`docker compose` 则会失败