### PR TITLE
ddns: remove ipv6 nameservers, support custom nameservers

### DIFF
--- a/cmd/dashboard/controller/member_api.go
+++ b/cmd/dashboard/controller/member_api.go
@@ -1012,6 +1012,7 @@ type settingForm struct {
 	DashboardTheme          string
 	CustomCode              string
 	CustomCodeDashboard     string
+	CustomNameservers       string
 	ViewPassword            string
 	IgnoredIPNotification   string
 	IPChangeNotificationTag string // IP变更提醒的通知组
@@ -1078,6 +1079,7 @@ func (ma *memberAPI) updateSetting(c *gin.Context) {
 	singleton.Conf.Site.DashboardTheme = sf.DashboardTheme
 	singleton.Conf.Site.CustomCode = sf.CustomCode
 	singleton.Conf.Site.CustomCodeDashboard = sf.CustomCodeDashboard
+	singleton.Conf.DNSServers = sf.CustomNameservers
 	singleton.Conf.Site.ViewPassword = sf.ViewPassword
 	singleton.Conf.Oauth2.Admin = sf.Admin
 	// 保证NotificationTag不为空
@@ -1093,6 +1095,8 @@ func (ma *memberAPI) updateSetting(c *gin.Context) {
 	}
 	// 更新系统语言
 	singleton.InitLocalizer()
+	// 更新DNS服务器
+	singleton.OnNameserverUpdate()
 	c.JSON(http.StatusOK, model.Response{
 		Code: http.StatusOK,
 	})

--- a/model/config.go
+++ b/model/config.go
@@ -125,6 +125,8 @@ type Config struct {
 	IgnoredIPNotificationServerIDs map[uint64]bool // [ServerID] -> bool(值为true代表当前ServerID在特定服务器列表内）
 	MaxTCPPingValue                int32
 	AvgPingCount                   int
+
+	DNSServers string
 }
 
 // Read 读取配置文件并应用

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -13,7 +13,7 @@ import (
 var (
 	Json = jsoniter.ConfigCompatibleWithStandardLibrary
 
-	DNSServers = []string{"1.1.1.1:53", "223.5.5.5:53", "[2606:4700:4700::1111]:53", "[2400:3200::1]:53"}
+	DNSServers = []string{"1.1.1.1:53", "223.5.5.5:53"}
 )
 
 func IsWindows() bool {

--- a/resource/l10n/en-US.toml
+++ b/resource/l10n/en-US.toml
@@ -747,3 +747,6 @@ other = "Expired"
 
 [Days]
 other = "d"
+
+[CustomNameservers]
+other = "Custom Public DNS Nameservers for DDNS (separate with comma)"

--- a/resource/l10n/es-ES.toml
+++ b/resource/l10n/es-ES.toml
@@ -747,3 +747,6 @@ other = "Expired"
 
 [Days]
 other = "d"
+
+[CustomNameservers]
+other = "Servidores DNS públicos personalizados para DDNS (separar con coma)"

--- a/resource/l10n/zh-CN.toml
+++ b/resource/l10n/zh-CN.toml
@@ -747,3 +747,6 @@ other = "已到期"
 
 [Days]
 other = "天"
+
+[CustomNameservers]
+other = "自定义DDNS使用的公共DNS服务器（逗号分隔）"

--- a/resource/l10n/zh-TW.toml
+++ b/resource/l10n/zh-TW.toml
@@ -747,3 +747,6 @@ other = "已到期"
 
 [Days]
 other = "天"
+
+[CustomNameservers]
+other = "自訂DDNS使用的公共DNS伺服器（逗號分隔）"

--- a/resource/template/dashboard-default/setting.html
+++ b/resource/template/dashboard-default/setting.html
@@ -54,6 +54,10 @@
                 <input type="text" name="GRPCHost" placeholder="" value="{{.Conf.GRPCHost}}">
             </div>
             <div class="field">
+                <label>{{tr "CustomNameservers"}}</label>
+                <input type="text" name="CustomNameservers" placeholder="" value="{{.Conf.DNSServers}}">
+            </div>
+            <div class="field">
                 <label>{{tr "IPChangeAlert"}}</label>
             </div>
             <div class="ui segment">

--- a/service/singleton/ddns.go
+++ b/service/singleton/ddns.go
@@ -20,6 +20,7 @@ var (
 
 func initDDNS() {
 	OnDDNSUpdate()
+	OnNameserverUpdate()
 }
 
 func OnDDNSUpdate() {
@@ -31,6 +32,10 @@ func OnDDNSUpdate() {
 	for i := 0; i < len(ddns); i++ {
 		ddnsCache[ddns[i].ID] = ddns[i]
 	}
+}
+
+func OnNameserverUpdate() {
+	ddns2.InitDNSServers(Conf.DNSServers)
 }
 
 func GetDDNSProvidersFromProfiles(profileId []uint64, ip *ddns2.IP) ([]*ddns2.Provider, error) {


### PR DESCRIPTION
查询操作如果成功一般并不会执行到ipv6的情况，加了ipv6还会导致单栈机器直接返回，故删除
在配置文件中加入自定义DNS服务器字段，格式为 `1.1.1.1:53,8.8.8.8:53...`