### PR TITLE
ddns: add listProviders api

### DIFF
--- a/cmd/dashboard/controller/controller.go
+++ b/cmd/dashboard/controller/controller.go
@@ -71,6 +71,7 @@ func routers(r *gin.Engine) {
 	auth.POST("/batch-delete/server", commonHandler(batchDeleteServer))
 
 	auth.GET("/ddns", commonHandler(listDDNS))
+	auth.GET("/ddns/providers", commonHandler(listProviders))
 	auth.POST("/ddns", commonHandler(newDDNS))
 	auth.PATCH("/ddns/:id", commonHandler(editDDNS))
 	auth.POST("/batch-delete/ddns", commonHandler(batchDeleteDDNS))

--- a/cmd/dashboard/controller/ddns.go
+++ b/cmd/dashboard/controller/ddns.go
@@ -235,7 +235,7 @@ func listDDNS(c *gin.Context) error {
 // @Security BearerAuth
 // @Tags auth required
 // @Produce json
-// @Success 200 {object} model.CommonResponse[[]string]]
+// @Success 200 {object} model.CommonResponse[[]string]
 // @Router /ddns/providers [get]
 func listProviders(c *gin.Context) error {
 	c.JSON(http.StatusOK, model.CommonResponse[[]string]{

--- a/cmd/dashboard/controller/ddns.go
+++ b/cmd/dashboard/controller/ddns.go
@@ -227,3 +227,20 @@ func listDDNS(c *gin.Context) error {
 	})
 	return nil
 }
+
+// List DDNS Providers
+// @Summary List DDNS providers
+// @Schemes
+// @Description List DDNS providers
+// @Security BearerAuth
+// @Tags auth required
+// @Produce json
+// @Success 200 {object} model.CommonResponse[[]string]]
+// @Router /ddns/providers [get]
+func listProviders(c *gin.Context) error {
+	c.JSON(http.StatusOK, model.CommonResponse[[]string]{
+		Success: true,
+		Data:    model.ProviderList,
+	})
+	return nil
+}

--- a/cmd/dashboard/controller/member_api.go
+++ b/cmd/dashboard/controller/member_api.go
@@ -720,7 +720,7 @@ type ddnsForm struct {
 	EnableIPv4         string
 	EnableIPv6         string
 	Name               string
-	Provider           uint8
+	Provider           string
 	DomainsRaw         string
 	AccessID           string
 	AccessSecret       string

--- a/cmd/dashboard/controller/member_page.go
+++ b/cmd/dashboard/controller/member_page.go
@@ -82,9 +82,9 @@ func (mp *memberPage) ddns(c *gin.Context) {
 	singleton.DB.Find(&data)
 	c.HTML(http.StatusOK, "dashboard-", gin.H{
 		// "Title":        singleton.Localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "DDNS"}),
-		"DDNS":         data,
-		"ProviderMap":  model.ProviderMap,
-		"ProviderList": model.ProviderList,
+		"DDNS": data,
+		//"ProviderMap": model.ProviderMap,
+		//"ProviderList": model.ProviderList,
 	})
 }
 

--- a/model/ddns.go
+++ b/model/ddns.go
@@ -7,73 +7,32 @@ import (
 )
 
 const (
-	ProviderDummy = iota
-	ProviderWebHook
-	ProviderCloudflare
-	ProviderTencentCloud
+	ProviderDummy        = "dummy"
+	ProviderWebHook      = "webhook"
+	ProviderCloudflare   = "cloudflare"
+	ProviderTencentCloud = "tencentcloud"
 )
 
-const (
-	_Dummy        = "dummy"
-	_WebHook      = "webhook"
-	_Cloudflare   = "cloudflare"
-	_TencentCloud = "tencentcloud"
-)
-
-var ProviderMap = map[uint8]string{
-	ProviderDummy:        _Dummy,
-	ProviderWebHook:      _WebHook,
-	ProviderCloudflare:   _Cloudflare,
-	ProviderTencentCloud: _TencentCloud,
-}
-
-var ProviderList = []DDNSProvider{
-	{
-		Name: _Dummy,
-		ID:   ProviderDummy,
-	},
-	{
-		Name:         _Cloudflare,
-		ID:           ProviderCloudflare,
-		AccessSecret: true,
-	},
-	{
-		Name:         _TencentCloud,
-		ID:           ProviderTencentCloud,
-		AccessID:     true,
-		AccessSecret: true,
-	},
-	// Least frequently used, always place this at the end
-	{
-		Name:               _WebHook,
-		ID:                 ProviderWebHook,
-		AccessID:           true,
-		AccessSecret:       true,
-		WebhookURL:         true,
-		WebhookMethod:      true,
-		WebhookRequestType: true,
-		WebhookRequestBody: true,
-		WebhookHeaders:     true,
-	},
+var ProviderList = []string{
+	ProviderDummy, ProviderWebHook, ProviderCloudflare, ProviderTencentCloud,
 }
 
 type DDNSProfile struct {
 	Common
-	EnableIPv4         *bool
-	EnableIPv6         *bool
-	MaxRetries         uint64
-	Name               string
-	Provider           uint8
-	AccessID           string
-	AccessSecret       string
-	WebhookURL         string
-	WebhookMethod      uint8
-	WebhookRequestType uint8
-	WebhookRequestBody string
-	WebhookHeaders     string
-
-	Domains    []string `gorm:"-"`
-	DomainsRaw string
+	EnableIPv4         *bool    `json:"enable_ipv4,omitempty"`
+	EnableIPv6         *bool    `json:"enable_ipv6,omitempty"`
+	MaxRetries         uint64   `json:"max_retries,omitempty"`
+	Name               string   `json:"name,omitempty"`
+	Provider           string   `json:"provider,omitempty"`
+	AccessID           string   `json:"access_id,omitempty"`
+	AccessSecret       string   `json:"access_secret,omitempty"`
+	WebhookURL         string   `json:"webhook_url,omitempty"`
+	WebhookMethod      uint8    `json:"webhook_method,omitempty"`
+	WebhookRequestType uint8    `json:"webhook_request_type,omitempty"`
+	WebhookRequestBody string   `json:"webhook_request_body,omitempty"`
+	WebhookHeaders     string   `json:"webhook_headers,omitempty"`
+	Domains            []string `json:"domains,omitempty" gorm:"-"`
+	DomainsRaw         string   `json:"domains_raw,omitempty"`
 }
 
 func (d DDNSProfile) TableName() string {
@@ -87,31 +46,19 @@ func (d *DDNSProfile) AfterFind(tx *gorm.DB) error {
 	return nil
 }
 
-type DDNSProvider struct {
-	Name               string
-	ID                 uint8
-	AccessID           bool
-	AccessSecret       bool
-	WebhookURL         bool
-	WebhookMethod      bool
-	WebhookRequestType bool
-	WebhookRequestBody bool
-	WebhookHeaders     bool
-}
-
 type DDNSForm struct {
-	ID                 uint64
-	MaxRetries         uint64
-	EnableIPv4         string
-	EnableIPv6         string
-	Name               string
-	Provider           uint8
-	DomainsRaw         string
-	AccessID           string
-	AccessSecret       string
-	WebhookURL         string
-	WebhookMethod      uint8
-	WebhookRequestType uint8
-	WebhookRequestBody string
-	WebhookHeaders     string
+	ID                 uint64 `json:"id,omitempty"`
+	MaxRetries         uint64 `json:"max_retries,omitempty"`
+	EnableIPv4         string `json:"enable_ipv4,omitempty"`
+	EnableIPv6         string `json:"enable_ipv6,omitempty"`
+	Name               string `json:"name,omitempty"`
+	Provider           string `json:"provider,omitempty"`
+	DomainsRaw         string `json:"domains_raw,omitempty"`
+	AccessID           string `json:"access_id,omitempty"`
+	AccessSecret       string `json:"access_secret,omitempty"`
+	WebhookURL         string `json:"webhook_url,omitempty"`
+	WebhookMethod      uint8  `json:"webhook_method,omitempty"`
+	WebhookRequestType uint8  `json:"webhook_request_type,omitempty"`
+	WebhookRequestBody string `json:"webhook_request_body,omitempty"`
+	WebhookHeaders     string `json:"webhook_headers,omitempty"`
 }

--- a/service/singleton/ddns.go
+++ b/service/singleton/ddns.go
@@ -67,7 +67,7 @@ func GetDDNSProvidersFromProfiles(profileId []uint64, ip *ddns2.IP) ([]*ddns2.Pr
 			provider.Setter = &tencentcloud.Provider{SecretId: profile.AccessID, SecretKey: profile.AccessSecret}
 			providers = append(providers, provider)
 		default:
-			return nil, fmt.Errorf("无法找到配置的DDNS提供者ID %d", profile.Provider)
+			return nil, fmt.Errorf("无法找到配置的DDNS提供者 %s", profile.Provider)
 		}
 	}
 	return providers, nil


### PR DESCRIPTION
用于前端获取DDNS提供商列表，
另把`DDNSProfile.Provider`改回字符串，避免再加新的接口去传键值对
增加json标签