### PR TITLE
fix(cli): display version without initializing app

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"context"
 	"fmt"
 	"log"
@@ -32,13 +33,6 @@ func init() {
 	flag.StringVarP(&dashboardCliParam.ConfigFile, "config", "c", "data/config.yaml", "配置文件路径")
 	flag.StringVar(&dashboardCliParam.DatebaseLocation, "db", "data/sqlite.db", "Sqlite3数据库文件路径")
 	flag.Parse()
-
-	// 初始化 dao 包
-	singleton.InitConfigFromPath(dashboardCliParam.ConfigFile)
-	singleton.InitTimezoneAndCache()
-	singleton.InitDBFromPath(dashboardCliParam.DatebaseLocation)
-	singleton.InitLocalizer()
-	initSystem()
 }
 
 func initSystem() {
@@ -59,8 +53,15 @@ func initSystem() {
 func main() {
 	if dashboardCliParam.Version {
 		fmt.Println(singleton.Version)
-		return
+		os.Exit(0)
 	}
+
+	// 初始化 dao 包
+	singleton.InitConfigFromPath(dashboardCliParam.ConfigFile)
+	singleton.InitTimezoneAndCache()
+	singleton.InitDBFromPath(dashboardCliParam.DatebaseLocation)
+	singleton.InitLocalizer()
+	initSystem()
 
 	// TODO 使用 cmux 在同一端口服务 HTTP 和 gRPC
 	singleton.CleanMonitorHistory()


### PR DESCRIPTION
This PR separates "showing version" from the entire program.

According to the original code, running "./dashboard -v" will produce the following errors:
```
panic: open data/config.yaml: no such file or directory

goroutine 1 [running]:
github.com/naiba/nezha/service/singleton.InitConfigFromPath(...)
github.com/naiba/nezha/service/singleton/singleton.go:49
main.init.0()
github.com/naiba/nezha/cmd/dashboard/main.go:37 +0x20b
```

In Go, the `init()` will run before the `main()`, and some codes in `init()` initialize the service. Therefore, we can check the version flag in the init stage, and after the version is displayed, the program exits.
