### PR TITLE
Add API to register server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitignore
+docker-compose.yml
+Dockerfile
+Dockerfile.dev
+
+
+data/*

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,63 @@
+# Use build arguments for Go version and architecture
+ARG GO_VERSION=1.22
+ARG BUILDARCH=amd64
+
+# Stage 1: Builder Stage
+# FROM golang:${GO_VERSION}-alpine AS builder
+FROM crazymax/xgo:${GO_VERSION} AS builder
+
+# Set up working directory
+WORKDIR /app
+
+# Step 1: Copy the source code
+COPY . .
+
+# use --mount=type=cache,target=/go/pkg/mod to cache the go mod
+# Step 2: Download dependencies
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod tidy && go mod download
+
+# Step 3: Build the Go application with CGO enabled and specified ldflags
+RUN --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=1 GOOS=linux go build -a \
+    -ldflags "-s -w --extldflags '-static -fpic'" \
+    -installsuffix cgo -o dashboard cmd/dashboard/main.go
+
+
+# Stage 2: Create the final image
+FROM alpine:latest
+
+ARG COUNTRY
+# Install required tools without caching index to minimize image size
+RUN if [ "$COUNTRY" = "CN" ] ; then \
+        echo "It is in China, updating the repositories"; \
+        sed -i 's#https\?://dl-cdn.alpinelinux.org/alpine#https://mirrors.tuna.tsinghua.edu.cn/alpine#g' /etc/apk/repositories; \
+    fi && \
+    apk update && apk add --no-cache tzdata && \
+    cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo 'Asia/Shanghai' >/etc/timezone && \
+    rm -rf /var/cache/apk/* && \
+    mkdir -p /dashboard/data
+
+
+# Copy the entrypoint script and ensure it is executable
+COPY ./script/entrypoint.sh /entrypoint.sh
+
+# Set up the entrypoint script
+RUN chmod +x /entrypoint.sh 
+
+WORKDIR /dashboard
+
+# Copy the statically linked binary from the builder stage
+COPY --from=builder /app/dashboard ./app
+# Copy the configuration file and the resource directory
+COPY ./script/config.yaml ./data/config.yaml
+COPY ./resource ./resource
+
+
+# Set up volume and expose ports
+VOLUME ["/dashboard/data"]
+EXPOSE 80 5555 443
+
+# Define the entrypoint
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  app:
+    build: 
+      context: .
+      dockerfile: Dockerfile.dev
+      args:
+        COUNTRY: CN
+    image: nezha:dev
+    container_name: nezha-dev
+    ports:
+      - ${NEZHA_PORT:-80}:18080
+      - 5555:5555
+    volumes:
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+      - ./data:/dashboard/data
+      # - ./resource:/dashboard/resource


### PR DESCRIPTION
## Summary
1. add 1 POST endpoints `/api/v1/server/register`
2. add `docker-compose.yml` and `Dockerfile.dev` for developing

## Usage

#### `/api/v1/server/register`

POST data format
```json
{
  "name": "abcd",
  "Tag": "",
  "Note": "",
  "HideForGuest": "on"
}
```
You can post a empty data `{}`, then it will use the default data
```
name=$IP
Tag="AutoRegister"
Note=""
HideForGuest="on"
```
If it contain query `simple=1` or `simple=true`, it will only return a secret string. Otherwise It return json
```json
{
"code":200,
"message":"Server created successfully",
"secret":"8GYwaxYuLfU7zl7ndC"
}
```

## Example

1. without `simple`

```bash
➜  ~ curl -X POST http://127.0.0.1:18080/api/v1/server/register \ 
  -H "Content-Type: application/json" \
  -H "Authorization: POXbxorKJBM8wPMKX8r2PdMblyXvpggB" \
  -d '{
    "name": "curl",
    "Tag": "",
    "Note": "",
    "HideForGuest": "on"
  }'
{"code":200,"message":"Server created successfully","secret":"XQ2HsGWRQvcVCBPWXh"}
```

2. with `simple=1`

 ```bash
➜  ~ curl -X POST http://127.0.0.1:18080/api/v1/server/register?simple=1 \
  -H "Content-Type: application/json" \
  -H "Authorization: POXbxorKJBM8wPMKX8r2PdMblyXvpggB" \
  -d '{
    "name": "curl",
    "Tag": "",
    "Note": "",
    "HideForGuest": "on"
  }'
"gv4eGLwyvHIR9y5E7p"
```