### PR TITLE
fix(auth): accept hyphenated agent metadata

### DIFF
--- a/service/rpc/auth.go
+++ b/service/rpc/auth.go
@@ -39,10 +39,7 @@ func (a *authHandler) check(ctx context.Context) (uint64, error) {
 		return 0, status.Errorf(codes.Unauthenticated, "获取 metaData 失败")
 	}
 
-	var clientSecret string
-	if value, ok := md["client_secret"]; ok {
-		clientSecret = strings.TrimSpace(value[0])
-	}
+	clientSecret := firstMetadataValue(md, "client-secret", "client_secret")
 
 	if clientSecret == "" {
 		return 0, status.Error(codes.Unauthenticated, "客户端认证失败")
@@ -50,10 +47,7 @@ func (a *authHandler) check(ctx context.Context) (uint64, error) {
 
 	ip, _ := ctx.Value(model.CtxKeyRealIP{}).(string)
 
-	var clientUUID string
-	if value, ok := md["client_uuid"]; ok {
-		clientUUID = value[0]
-	}
+	clientUUID := firstMetadataValue(md, "client-uuid", "client_uuid")
 
 	if _, err := uuid.ParseUUID(clientUUID); err != nil {
 		// Keep this counter on the same trigger surface as the
@@ -181,6 +175,15 @@ func (a *authHandler) check(ctx context.Context) (uint64, error) {
 	}
 
 	return clientID, nil
+}
+
+func firstMetadataValue(md metadata.MD, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := md[key]; ok && len(value) > 0 {
+			return strings.TrimSpace(value[0])
+		}
+	}
+	return ""
 }
 
 // authorizeAgentForUUID resolves a client UUID to the dashboard's internal

--- a/service/rpc/auth_test.go
+++ b/service/rpc/auth_test.go
@@ -25,6 +25,14 @@ func authCheckWithSecret(secret, uuid string) (uint64, error) {
 	return (&authHandler{}).Check(ctx)
 }
 
+func authCheckWithHyphenatedSecret(secret, uuid string) (uint64, error) {
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+		"client-secret", secret,
+		"client-uuid", uuid,
+	))
+	return (&authHandler{}).Check(ctx)
+}
+
 // authHandshakeUUID is RFC4122-shaped so it survives the uuid.ParseUUID gate
 // at the top of check(); setupAuthAgentFixture's "uuid-alice" / "uuid-bob"
 // only work for callers that bypass check() and exercise the inner helpers.
@@ -85,6 +93,18 @@ func setupAuthHandshakeFixture(t *testing.T) func() {
 		singleton.UserInfoMap = originalUserInfoMap
 		singleton.AgentSecretToUserId = originalAgentSecretToUserId
 		singleton.UserLock.Unlock()
+	}
+}
+
+func TestAuthCheckAcceptsHyphenatedMetadata(t *testing.T) {
+	defer setupAuthHandshakeFixture(t)()
+
+	cid, err := authCheckWithHyphenatedSecret("alice-global", authHandshakeUUID)
+	if err != nil {
+		t.Fatalf("hyphenated metadata must authenticate: %v", err)
+	}
+	if cid != 11 {
+		t.Fatalf("expected server ID 11, got %d", cid)
 	}
 }
 


### PR DESCRIPTION
## Why

Caddy v2.11.4 started dropping request headers whose names contain underscores before the handler chain runs.

Relevant Caddy source:
https://github.com/caddyserver/caddy/blob/v2.11.4/modules/caddyhttp/server.go#L497-L508

That code deletes headers like `client_secret` / `client_uuid` before `reverse_proxy` forwards the request. Because Nezha Agent currently sends its gRPC auth metadata using underscore names, agents behind Caddy v2.11.4 can fail dashboard authentication and appear offline.

This is not something users can fix in Caddyfile, because the headers are removed before `reverse_proxy` sees the request.

## What changed

Accept both metadata key formats during dashboard auth:

- new: `client-secret`, `client-uuid`
- legacy: `client_secret`, `client_uuid`

The legacy names are kept so existing agents continue to authenticate.

## Compatibility

This allows a safe rolling upgrade:

1. Upgrade dashboard first: old agents still work.
2. Upgrade agents later: new agents can authenticate through Caddy v2.11.4.

Companion agent PR: https://github.com/nezhahq/agent/pull/244

## Testing

- `go test ./service/rpc`
