### PR TITLE
Filter service stats based on user permissions

### DIFF
--- a/cmd/dashboard/controller/permission_matrix_test.go
+++ b/cmd/dashboard/controller/permission_matrix_test.go
@@ -268,7 +268,10 @@ func TestShowServiceFiltersCycleTransferStatsLikeServerList(t *testing.T) {
 	serviceSentinel, err := singleton.NewServiceSentinel(make(chan *model.Service, 2))
 	assert.NoError(t, err)
 	singleton.ServiceSentinelShared = serviceSentinel
-	t.Cleanup(func() { singleton.ServiceSentinelShared = originalServiceSentinel })
+	t.Cleanup(func() {
+		serviceSentinel.Close()
+		singleton.ServiceSentinelShared = originalServiceSentinel
+	})
 
 	singleton.AlertsLock.Lock()
 	originalCycleTransferStats := singleton.AlertsCycleTransferStatsStore
@@ -288,23 +291,27 @@ func TestShowServiceFiltersCycleTransferStatsLikeServerList(t *testing.T) {
 	})
 
 	tests := []struct {
-		name      string
-		viewer    *model.User
-		wantNames map[uint64]string
+		name         string
+		viewer       *model.User
+		wantServices []uint64
+		wantNames    map[uint64]string
 	}{
 		{
-			name:      "guest sees public servers only",
-			wantNames: map[uint64]string{1: "public server"},
+			name:         "guest sees public servers only",
+			wantServices: []uint64{10},
+			wantNames:    map[uint64]string{1: "public server"},
 		},
 		{
-			name:      "member sees public and owned hidden servers",
-			viewer:    &model.User{Common: model.Common{ID: 200}, Role: model.RoleMember},
-			wantNames: map[uint64]string{1: "public server", 3: "hidden member server"},
+			name:         "member sees public and owned hidden servers",
+			viewer:       &model.User{Common: model.Common{ID: 200}, Role: model.RoleMember},
+			wantServices: []uint64{10},
+			wantNames:    map[uint64]string{1: "public server", 3: "hidden member server"},
 		},
 		{
-			name:      "admin sees every server",
-			viewer:    &model.User{Common: model.Common{ID: 1}, Role: model.RoleAdmin},
-			wantNames: map[uint64]string{1: "public server", 2: "hidden admin server", 3: "hidden member server"},
+			name:         "admin sees every server",
+			viewer:       &model.User{Common: model.Common{ID: 1}, Role: model.RoleAdmin},
+			wantServices: []uint64{10, 11},
+			wantNames:    map[uint64]string{1: "public server", 2: "hidden admin server", 3: "hidden member server"},
 		},
 	}
 
@@ -317,8 +324,7 @@ func TestShowServiceFiltersCycleTransferStatsLikeServerList(t *testing.T) {
 
 			got, err := showService(ctx)
 			assert.NoError(t, err)
-			assert.Contains(t, got.Services, uint64(10))
-			assert.NotContains(t, got.Services, uint64(11))
+			assert.ElementsMatch(t, tc.wantServices, serviceResponseIDs(got.Services))
 			if assert.Contains(t, got.CycleTransferStats, uint64(7)) {
 				cycleStats := got.CycleTransferStats[7]
 				assert.Equal(t, tc.wantNames, cycleStats.ServerName)
@@ -333,6 +339,14 @@ func TestShowServiceFiltersCycleTransferStatsLikeServerList(t *testing.T) {
 			}
 		})
 	}
+}
+
+func serviceResponseIDs(stats map[uint64]model.ServiceResponseItem) []uint64 {
+	ids := make([]uint64, 0, len(stats))
+	for id := range stats {
+		ids = append(ids, id)
+	}
+	return ids
 }
 
 func decodeIDs[T ~uint64](t *testing.T, body []byte) []T {

--- a/cmd/dashboard/controller/service.go
+++ b/cmd/dashboard/controller/service.go
@@ -29,7 +29,7 @@ func showService(c *gin.Context) (*model.ServiceResponse, error) {
 	res, err, _ := requestGroup.Do(serviceResponseCacheKey(c), func() (any, error) {
 		singleton.AlertsLock.RLock()
 		defer singleton.AlertsLock.RUnlock()
-		stats := singleton.ServiceSentinelShared.CopyStats()
+		stats := filterServiceStatsForViewer(c, singleton.ServiceSentinelShared.CopyStats())
 		var cycleTransferStats map[uint64]model.CycleTransferStats
 		copier.Copy(&cycleTransferStats, singleton.AlertsCycleTransferStatsStore)
 		return []any{
@@ -44,6 +44,22 @@ func showService(c *gin.Context) (*model.ServiceResponse, error) {
 		Services:           res.([]any)[0].(map[uint64]model.ServiceResponseItem),
 		CycleTransferStats: res.([]any)[1].(map[uint64]model.CycleTransferStats),
 	}, nil
+}
+
+func filterServiceStatsForViewer(c *gin.Context, stats map[uint64]model.ServiceResponseItem) map[uint64]model.ServiceResponseItem {
+	if len(stats) == 0 {
+		return stats
+	}
+	services := singleton.ServiceSentinelShared.GetList()
+	filteredStats := make(map[uint64]model.ServiceResponseItem, len(stats))
+	for serviceID, stat := range stats {
+		service, ok := services[serviceID]
+		if !ok || !userCanViewService(c, service) {
+			continue
+		}
+		filteredStats[serviceID] = stat
+	}
+	return filteredStats
 }
 
 func serviceResponseCacheKey(c *gin.Context) string {

--- a/service/singleton/servicesentinel.go
+++ b/service/singleton/servicesentinel.go
@@ -438,11 +438,6 @@ func (ss *ServiceSentinel) CopyStats() map[uint64]model.ServiceResponseItem {
 
 	sri := make(map[uint64]model.ServiceResponseItem)
 	for k, service := range stats {
-		if service.service.HideForGuest {
-			delete(stats, k)
-			continue
-		}
-
 		service.ServiceName = service.service.Name
 		sri[k] = service.ServiceResponseItem
 	}


### PR DESCRIPTION
This pull request improves access control for service statistics in the dashboard by ensuring that users only see stats for services they are allowed to view. The main change is the introduction of a filtering function that checks user permissions before including service stats in the response. The test suite is also updated to reflect these stricter checks and verify correct visibility for different user roles.

**Access control improvements:**

* Added `filterServiceStatsForViewer` in `service.go` to filter service stats based on the current user's permissions, ensuring only authorized services are included in the response.
* Updated `showService` to use the new filtering function when returning service stats, replacing a previous implementation that only hid services from guests. [[1]](diffhunk://#diff-5f15a241c242b349e9ffdae908a6343d2c78cb7ddd19bf7be263bf86a3a984aeL32-R32) [[2]](diffhunk://#diff-a214d39c58df0383277c2baa4fe8f074ca28d9dc0286c5c5711936e518745e05L441-L445)

**Test updates:**

* Enhanced test cases in `permission_matrix_test.go` to specify expected visible services (`wantServices`) for each user role and check exact matches using `assert.ElementsMatch`. [[1]](diffhunk://#diff-7c7e8699e7128a9e2c559b70be5dbb5c29b1e32b7423e75bed5cb9d064764cbbR296-R313) [[2]](diffhunk://#diff-7c7e8699e7128a9e2c559b70be5dbb5c29b1e32b7423e75bed5cb9d064764cbbL320-R327)
* Added helper function `serviceResponseIDs` to extract service IDs from the response for easier comparison in tests.
* Improved cleanup in tests to properly close the `ServiceSentinel` and restore global state.